### PR TITLE
Ensure second SYSVAD instance shows yellow bang

### DIFF
--- a/sysvad/common.cpp
+++ b/sysvad/common.cpp
@@ -586,7 +586,9 @@ Return Value:
     //
     if (InterlockedCompareExchange(&CAdapterCommon::m_AdapterInstances, 1, 0) != 0)
     {
-        ntStatus = STATUS_DEVICE_BUSY;
+        // Fail initialization so Plug and Play marks the device with a
+        // yellow bang (Code 10) instead of crashing due to a second instance.
+        ntStatus = STATUS_DEVICE_CONFIGURATION_ERROR;
         DPF(D_ERROR, ("NewAdapterCommon failed, only one instance is allowed"));
         goto Done;
     }


### PR DESCRIPTION
## Summary
- fail `CAdapterCommon` initialization with `STATUS_DEVICE_CONFIGURATION_ERROR` when a second instance is created

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684633106d6c83248f06a6bb06b36cd0