### PR TITLE
Implement loopback dispatch wrapper

### DIFF
--- a/sysvad/adapter.cpp
+++ b/sysvad/adapter.cpp
@@ -46,10 +46,6 @@ typedef void (*fnPcDriverUnload) (PDRIVER_OBJECT);
 fnPcDriverUnload gPCDriverUnloadRoutine = NULL;
 extern "C" DRIVER_UNLOAD DriverUnload;
 
-NTSTATUS LoopbackControl_CreateDevice(_In_ PDRIVER_OBJECT DriverObject);
-void LoopbackControl_DeleteDevice();
-NTSTATUS LoopbackBuffer_Initialize();
-void LoopbackBuffer_Cleanup();
 
 #ifdef _USE_SingleComponentMultiFxStates
 C_ASSERT(sizeof(POHANDLE) == sizeof(PVOID));
@@ -336,6 +332,7 @@ Environment:
 
     ReleaseRegistryStringBuffer();
 
+    LoopbackControl_RemoveDispatch(DriverObject);
     LoopbackControl_DeleteDevice();
     LoopbackBuffer_Cleanup();
 
@@ -592,6 +589,8 @@ Return Value:
         ntStatus,
         DPF(D_ERROR, ("PcInitializeAdapterDriver failed, 0x%x", ntStatus)),
         Done);
+
+    LoopbackControl_InstallDispatch(DriverObject);
 
     //
     // To intercept stop/remove/surprise-remove.

--- a/sysvad/loopback.h
+++ b/sysvad/loopback.h
@@ -24,3 +24,8 @@ void LoopbackBuffer_Write(_In_reads_bytes_(Length) PBYTE Data, _In_ ULONG Length
 ULONG LoopbackBuffer_Read(_Out_writes_bytes_(Length) PBYTE Data, _In_ ULONG Length);
 ULONG LoopbackBuffer_Available();
 KEVENT* LoopbackBuffer_GetEvent();
+
+NTSTATUS LoopbackControl_CreateDevice(_In_ PDRIVER_OBJECT DriverObject);
+void LoopbackControl_DeleteDevice();
+void LoopbackControl_InstallDispatch(_In_ PDRIVER_OBJECT DriverObject);
+void LoopbackControl_RemoveDispatch(_In_ PDRIVER_OBJECT DriverObject);


### PR DESCRIPTION
## Summary
- preserve portcls dispatch table and install a wrapper dispatch
- expose install/remove functions in headers
- integrate dispatch install/remove into driver entry/unload

## Testing
- `make -n` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_b_68463f8cf5888324a67f741edfc2b770