### PR TITLE
Handle zero-length driver data

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -222,10 +222,10 @@ int wmain(int argc, wchar_t** argv)
             bytesReturned = 0;
         }
 
-        if (bytesReturned < bytesNeeded)
-            ZeroMemory(buffer + bytesReturned, bytesNeeded - bytesReturned);
-
-        CopyMemory(pData, buffer, bytesNeeded);
+        DWORD copyBytes = min(bytesReturned, bytesNeeded);
+        CopyMemory(pData, buffer, copyBytes);
+        if (copyBytes < bytesNeeded)
+            ZeroMemory(pData + copyBytes, bytesNeeded - copyBytes);
 
         if (hFile != INVALID_HANDLE_VALUE && bytesReturned > 0)
         {


### PR DESCRIPTION
## Summary
- prevent overwriting the local buffer when DeviceIoControl returns 0 bytes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68465e644fa08324a3f0f2f8f377392b