### PR TITLE
Enable loopback buffer writes

### DIFF
--- a/sysvad/adapter.cpp
+++ b/sysvad/adapter.cpp
@@ -250,10 +250,10 @@ _Dispatch_type_(IRP_MJ_PNP)
 DRIVER_DISPATCH PnpHandler;
 
 //
-// Rendering streams are not saved to a file by default. Use the registry value 
-// DoNotCreateDataFiles (DWORD) = 0 to override this default.
+// Rendering streams are saved to a file by default. Set the registry value
+// DoNotCreateDataFiles (DWORD) to 1 to disable this behaviour.
 //
-DWORD g_DoNotCreateDataFiles = 1;  // default is off.
+DWORD g_DoNotCreateDataFiles = 0;  // capture enabled by default.
 DWORD g_DisableToneGenerator = 0;  // default is to generate tones.
 UNICODE_STRING g_RegistryPath;      // This is used to store the registry settings path for the driver
 


### PR DESCRIPTION
## Summary
- default to capturing audio so the loopback buffer receives data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684660cc70948324965faf5b6e5e12a6