### PR TITLE
Limit endpoints to a single speaker and mic

### DIFF
--- a/sysvad/TabletAudioSample/minipairs.h
+++ b/sysvad/TabletAudioSample/minipairs.h
@@ -164,12 +164,12 @@ static
 ENDPOINT_MINIPAIR SpeakerMiniports =
 {
     eSpeakerDevice,
-    L"TopologySpeaker",                                     // make sure this or the template name matches with KSNAME_TopologySpeaker in the inf's [Strings] section 
+    L"folkaurix_speaker_topo",                               // topology name for the speaker
     NULL,                                                   // optional template name
     CreateMiniportTopologySYSVAD,
     &SpeakerTopoMiniportFilterDescriptor,
     0, NULL,                                                // Interface properties
-    L"WaveSpeaker",                                         // make sure this or the template name matches with KSNAME_WaveSpeaker in the inf's [Strings] section
+    L"folkaurix_speaker",                                   // render device name
     NULL,                                                   // optional template name
     CreateMiniportWaveRTSYSVAD,
     &SpeakerWaveMiniportFilterDescriptor,
@@ -181,9 +181,7 @@ ENDPOINT_MINIPAIR SpeakerMiniports =
     SpeakerTopologyPhysicalConnections,
     SIZEOF_ARRAY(SpeakerTopologyPhysicalConnections),
     ENDPOINT_OFFLOAD_SUPPORTED,
-    SpeakerModulesWaveFilter, 
-    SIZEOF_ARRAY(SpeakerModulesWaveFilter),
-    &SpeakerModuleNotificationDeviceId,
+    NULL, 0, NULL,                                          // no audio modules
 };
 
 /*********************************************************************
@@ -352,12 +350,12 @@ static
 ENDPOINT_MINIPAIR MicInMiniports =
 {
     eMicInDevice,
-    L"TopologyMicIn",                       // make sure this or the template name matches with KSNAME_TopologyMicIn in the inf's [Strings] section 
+    L"folkaurix_mic_topo",                  // topology name for the microphone
     NULL,                                   // optional template name
     CreateMiniportTopologySYSVAD,
     &MicInTopoMiniportFilterDescriptor,
     0, NULL,                                // Interface properties
-    L"WaveMicIn",                           // make sure this or the template name matches with KSNAME_WaveMicIn in the inf's [Strings] section
+    L"folkaurix_mic",                       // capture device name
     NULL,                                   // optional template name
     CreateMiniportWaveRTSYSVAD,
     &MicInWaveMiniportFilterDescriptor,
@@ -507,12 +505,9 @@ ENDPOINT_MINIPAIR MicArray3Miniports =
 // Render miniport pairs.
 //
 static
-PENDPOINT_MINIPAIR  g_RenderEndpoints[] = 
+PENDPOINT_MINIPAIR  g_RenderEndpoints[] =
 {
     &SpeakerMiniports,
-    &SpeakerHpMiniports,
-    &HdmiMiniports,
-    &SpdifMiniports,
 };
 
 #define g_cRenderEndpoints  (SIZEOF_ARRAY(g_RenderEndpoints))
@@ -522,12 +517,9 @@ PENDPOINT_MINIPAIR  g_RenderEndpoints[] =
 // Capture miniport pairs.
 //
 static
-PENDPOINT_MINIPAIR  g_CaptureEndpoints[] = 
+PENDPOINT_MINIPAIR  g_CaptureEndpoints[] =
 {
     &MicInMiniports,
-    &MicArray1Miniports,
-    &MicArray2Miniports,
-    &MicArray3Miniports,
 };
 
 #define g_cCaptureEndpoints (SIZEOF_ARRAY(g_CaptureEndpoints))


### PR DESCRIPTION
## Summary
- rename device endpoints to `folkaurix_speaker` and `folkaurix_mic`
- disable audio modules for the speaker endpoint
- reduce exported endpoints to one speaker and one mic
- revert unintended changes to ComponentizedAudioSample.inx

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68467c70b46483248eb18cbac32ecff5