### PR TITLE
Fix sideband compile errors

### DIFF
--- a/sysvad/EndpointsCommon/MiniportAudioEngineNode.cpp
+++ b/sysvad/EndpointsCommon/MiniportAudioEngineNode.cpp
@@ -766,6 +766,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeChannelCount(_Out_  UINT32 *_pulChannelCount)
 
     DPF_ENTER(("[CMiniportWaveRT::GetVolumeChannelCount]"));
 
+#if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsVolumeSupported(m_DeviceType))
     {
         ULONG propSize = 0;
@@ -775,6 +776,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeChannelCount(_Out_  UINT32 *_pulChannelCount)
         *_pulChannelCount = pMembers->MembersCount;
     }
     else
+#endif
     {
         *_pulChannelCount = m_DeviceMaxChannels;
     }
@@ -789,6 +791,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeSteppings(_Out_writes_bytes_(_ui32DataSize) P
     ASSERT (_pKsPropStepLong);
     DPF_ENTER(("[CMiniportWaveRT::GetVolumeSteppings]"));
 
+#if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsVolumeSupported(m_DeviceType))
     {
         // For Sideband Devices copy values from the Sideband DDI property descriptor
@@ -814,6 +817,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeSteppings(_Out_writes_bytes_(_ui32DataSize) P
         }
     }
     else
+#endif
     {
         ASSERT(ulChannelCount <= m_DeviceMaxChannels);
         if (ulChannelCount > m_DeviceMaxChannels)
@@ -852,11 +856,13 @@ NTSTATUS CMiniportWaveRT::GetChannelVolume(_In_  UINT32 _uiChannel, _Out_ LONG *
 
     NTSTATUS status = STATUS_SUCCESS;
 
+#if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsVolumeSupported(m_DeviceType))
     {
         status = m_pSidebandDevice->GetVolume(m_DeviceType, _uiChannel, _pVolume);
     }
     else
+#endif
     {
         if (_uiChannel == ALL_CHANNELS_ID)
         {
@@ -877,11 +883,13 @@ NTSTATUS CMiniportWaveRT::SetChannelVolume(_In_  UINT32 _uiChannel, _In_  LONG _
     PAGED_CODE ();
     DPF_ENTER(("[CMiniportWaveRT::SetChannelVolume]"));
 
+#if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsVolumeSupported(m_DeviceType))
     {
         return m_pSidebandDevice->SetVolume(m_DeviceType, _uiChannel, _Volume);
     }
     else
+#endif
     {
         // Normalize volume only for non-sideband devices.
         // Volume levels are governed by Sideband provider
@@ -979,6 +987,7 @@ NTSTATUS CMiniportWaveRT::GetMuteChannelCount(_Out_  UINT32 *_pulChannelCount)
 
     DPF_ENTER(("[CMiniportWaveRT::GetMuteChannelCount]"));
 
+#if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsMuteSupported(m_DeviceType))
     {
         ULONG propSize = 0;
@@ -988,6 +997,7 @@ NTSTATUS CMiniportWaveRT::GetMuteChannelCount(_Out_  UINT32 *_pulChannelCount)
         *_pulChannelCount = pMembers->MembersCount;
     }
     else
+#endif
     {
         *_pulChannelCount = m_DeviceMaxChannels;
     }
@@ -1002,6 +1012,7 @@ NTSTATUS CMiniportWaveRT::GetMuteSteppings(_Out_writes_bytes_(_ui32DataSize)  PK
     ASSERT (_pKsPropStepLong);
     DPF_ENTER(("[CMiniportWaveRT::GetMuteSteppings]"));
 
+#if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsMuteSupported(m_DeviceType))
     {
         // For Sideband Devices copy values from the Sideband DDI property descriptor
@@ -1028,6 +1039,7 @@ NTSTATUS CMiniportWaveRT::GetMuteSteppings(_Out_writes_bytes_(_ui32DataSize)  PK
 
     }
     else
+#endif
     {
         ASSERT(ulChannelCount <= m_DeviceMaxChannels);
 
@@ -1052,11 +1064,13 @@ NTSTATUS CMiniportWaveRT::GetChannelMute(_In_  UINT32 _uiChannel, _Out_  BOOL *_
     ASSERT (_pbMute);
     DPF_ENTER(("[CMiniportWaveRT::GetChannelMute]"));
 
+#if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsMuteSupported(m_DeviceType))
     {
         *_pbMute = m_pSidebandDevice->GetMute(m_DeviceType, _uiChannel);
     }
     else
+#endif
     {
         if (_uiChannel == ALL_CHANNELS_ID)
         {
@@ -1077,10 +1091,12 @@ NTSTATUS CMiniportWaveRT::SetChannelMute(_In_  UINT32 _uiChannel, _In_  BOOL _bM
     PAGED_CODE ();
     DPF_ENTER(("[CMiniportWaveRT::SetChannelMute]"));
 
+#if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsMuteSupported(m_DeviceType))
     {
         return m_pSidebandDevice->SetMute(m_DeviceType, _uiChannel, _bMute);
     }
+#endif
 
     // Will reach here only if not handled through Sideband
     if (_uiChannel == ALL_CHANNELS_ID)


### PR DESCRIPTION
## Summary
- avoid compile errors when SYSVAD sideband macros are not defined
- guard IsSidebandDevice blocks with `SYSVAD_BTH_BYPASS` or `SYSVAD_USB_SIDEBAND`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_684736304d2c83249045292f3f4ac3d1