### PR TITLE
Fix INF warning for sample driver

### DIFF
--- a/sysvad/TabletAudioSample/ComponentizedAudioSample.inx
+++ b/sysvad/TabletAudioSample/ComponentizedAudioSample.inx
@@ -334,6 +334,8 @@ HKR,FX\0,%PKEY_FX_KeywordDetector_ModeEffectClsid%,,%FX_DISCOVER_EFFECTS_APO_CLS
 [SYSVAD_SA.NT]
 Include=ks.inf,wdmaudio.inf
 Needs=KS.Registration, WDMAUDIO.Registration
+CopyFiles=SYSVAD_SA.CopyList
+AddReg=SYSVAD_SA.AddReg
 
 [SYSVAD_SA.NT.Interfaces]
 ;


### PR DESCRIPTION
## Summary
- reference INF CopyList and AddReg sections for TabletAudioSample

## Testing
- `pre-commit` *(fails: no pre-commit setup)*

------
https://chatgpt.com/codex/tasks/task_b_68475bc3622883248f2bd7c1a418a6d2