### PR TITLE
Fix driver buffer handling for IOCTL_SYSVAD_GET_LOOPBACK_DATA

### DIFF
--- a/sysvad/loopbackcontrol.cpp
+++ b/sysvad/loopbackcontrol.cpp
@@ -44,9 +44,22 @@ static NTSTATUS LoopbackDispatch(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP 
         if (irpSp->Parameters.DeviceIoControl.IoControlCode == IOCTL_SYSVAD_GET_LOOPBACK_DATA)
         {
             ULONG outLen = irpSp->Parameters.DeviceIoControl.OutputBufferLength;
-            PBYTE outBuf = (PBYTE)Irp->AssociatedIrp.SystemBuffer;
-            info = LoopbackBuffer_Read(outBuf, outLen);
-            status = STATUS_SUCCESS;
+            PBYTE outBuf = NULL;
+
+            if (Irp->MdlAddress)
+            {
+                outBuf = (PBYTE)MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
+            }
+
+            if (outBuf)
+            {
+                info = LoopbackBuffer_Read(outBuf, outLen);
+                status = STATUS_SUCCESS;
+            }
+            else
+            {
+                status = STATUS_INSUFFICIENT_RESOURCES;
+            }
         }
         break;
     default:


### PR DESCRIPTION
## Summary
- fix loopback IOCTL to use MDL-based buffer access when DO_DIRECT_IO is enabled

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684766a8dba08324be3ec8c2ce80d100