### PR TITLE
Simplify debug macros

### DIFF
--- a/sysvad/EndpointsCommon/AudioModuleHelper.cpp
+++ b/sysvad/EndpointsCommon/AudioModuleHelper.cpp
@@ -33,7 +33,7 @@ AudioModule_GenericHandler_BasicSupport(
     ULONG       cbFullProperty  = 0;
     ULONG       cbDataListSize  = 0;
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PAGED_CODE();
 
@@ -50,7 +50,7 @@ AudioModule_GenericHandler_BasicSupport(
     {
         ASSERT(FALSE);
         *BufferCb = 0;
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return ntStatus;
     }
 
@@ -63,7 +63,7 @@ AudioModule_GenericHandler_BasicSupport(
     {
         ASSERT(FALSE);
         *BufferCb = 0;
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return ntStatus;
     }
 
@@ -88,7 +88,7 @@ AudioModule_GenericHandler_BasicSupport(
         propDesc->MembersListCount  = 1;
         propDesc->Reserved          = 0;
 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // if return buffer can also hold a list description, return it too
         if(*BufferCb  >= cbFullProperty)
         {
@@ -106,7 +106,7 @@ AudioModule_GenericHandler_BasicSupport(
 
             RtlCopyMemory(array, ParameterInfo->ValidSet, cbDataListSize);
 
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             // set the return value size
             *BufferCb  = cbFullProperty;
         } 
@@ -117,7 +117,7 @@ AudioModule_GenericHandler_BasicSupport(
     } 
     else if(*BufferCb  >= sizeof(ULONG))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // if return buffer can hold a ULONG, return the access flags
         PULONG accessFlags = PULONG(Buffer);
 
@@ -130,7 +130,7 @@ AudioModule_GenericHandler_BasicSupport(
         ntStatus = STATUS_BUFFER_TOO_SMALL;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerBasicSupportVolume
 
@@ -145,7 +145,7 @@ IsAudioModuleParameterValid(
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     ULONG       i = 0;
     ULONG       j = 0;
@@ -224,7 +224,7 @@ IsAudioModuleParameterValid(
         }
 
         //
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // If value is -1, return error.
         //
         if (i == ParameterInfo->Size)
@@ -237,7 +237,7 @@ IsAudioModuleParameterValid(
     validParam = TRUE;
     
 exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return validParam;
 }
 
@@ -260,12 +260,12 @@ AudioModule_FindModuleInList(
         if (IsEqualGUIDAligned(*(module->Descriptor->ClassId), *ClassId) &&
             module->InstanceId == InstanceId)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return module;
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return NULL;
 }
 
@@ -286,7 +286,7 @@ AudioModule_GenericHandler(
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     UNREFERENCED_PARAMETER(ParameterId);
     
@@ -295,7 +295,7 @@ AudioModule_GenericHandler(
     // Handle KSPROPERTY_TYPE_BASICSUPPORT query
     if (Verb & KSPROPERTY_TYPE_BASICSUPPORT)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return AudioModule_GenericHandler_BasicSupport(ParameterInfo, OutBuffer, OutBufferCb);
     }
 
@@ -307,7 +307,7 @@ AudioModule_GenericHandler(
         if (!(ParameterInfo->AccessFlags & KSPROPERTY_TYPE_GET))
         {
             *OutBufferCb = 0;
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_DEVICE_REQUEST;
         }
         
@@ -315,20 +315,20 @@ AudioModule_GenericHandler(
         if (*OutBufferCb == 0)
         {
             *OutBufferCb = cbMinSize;
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_BUFFER_OVERFLOW;
         }
         if (*OutBufferCb < cbMinSize)
         {
             *OutBufferCb = 0;
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_BUFFER_TOO_SMALL;
         }
         else
         {
             RtlCopyMemory(OutBuffer, CurrentValue, ParameterInfo->Size);
             *OutBufferCb = cbMinSize;
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_SUCCESS;
         }
     }
@@ -339,14 +339,14 @@ AudioModule_GenericHandler(
         // Verify it is a write prop.
         if (!(ParameterInfo->AccessFlags & KSPROPERTY_TYPE_SET))
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_DEVICE_REQUEST;
         }
 
         // Validate parameter.
         if (!IsAudioModuleParameterValid(ParameterInfo, InBuffer, InBufferCb))
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_PARAMETER;
         }
 
@@ -357,11 +357,11 @@ AudioModule_GenericHandler(
             *ParameterChanged = TRUE;
         }
         
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_SUCCESS;
     }
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_INVALID_DEVICE_REQUEST;
 }
 
@@ -382,10 +382,10 @@ AudioModule_GenericHandler_ModulesListRequest(
 
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     // Note: return an empty list when no modules are present.
     //
     
@@ -393,7 +393,7 @@ AudioModule_GenericHandler_ModulesListRequest(
     if (PropertyRequest->Verb & KSPROPERTY_TYPE_BASICSUPPORT)
     {
         ULONG flags = KSPROPERTY_TYPE_GET | KSPROPERTY_TYPE_BASICSUPPORT;
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return PropertyHandler_BasicSupport(PropertyRequest, flags, VT_ILLEGAL);
     }
 
@@ -412,7 +412,7 @@ AudioModule_GenericHandler_ModulesListRequest(
         if (!NT_SUCCESS(ntStatus))
         {
             ASSERT(FALSE);
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return ntStatus;
         }
         
@@ -420,7 +420,7 @@ AudioModule_GenericHandler_ModulesListRequest(
         if (!NT_SUCCESS(ntStatus))
         {
             ASSERT(FALSE);
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return ntStatus;
         }
 
@@ -428,12 +428,12 @@ AudioModule_GenericHandler_ModulesListRequest(
         if (PropertyRequest->ValueSize == 0)
         {
             PropertyRequest->ValueSize = cbMinSize;
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_BUFFER_OVERFLOW;
         }
         if (PropertyRequest->ValueSize < cbMinSize)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_BUFFER_TOO_SMALL;
         }
         
@@ -463,11 +463,11 @@ AudioModule_GenericHandler_ModulesListRequest(
         ksMultipleItem->Count = AudioModuleCount;
 
         PropertyRequest->ValueSize = ksMultipleItem->Size;
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_SUCCESS;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_INVALID_DEVICE_REQUEST;
 } // AudioModule_GenericHandler_ModulesListRequest
 
@@ -484,7 +484,7 @@ AudioModule_GenericHandler_ModuleCommand(
     
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     //
     // Basic parameter validation.
@@ -492,7 +492,7 @@ AudioModule_GenericHandler_ModuleCommand(
     if (AudioModules == NULL || AudioModuleCount == 0)
     {
         // endpoint/stream doesn't have any modules.
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_DEVICE_REQUEST;
     }
     
@@ -501,7 +501,7 @@ AudioModule_GenericHandler_ModuleCommand(
     if (PropertyRequest->InstanceSize < (sizeof(KSAUDIOMODULE_PROPERTY) - 
             RTL_SIZEOF_THROUGH_FIELD(KSAUDIOMODULE_PROPERTY, Property)))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -521,7 +521,7 @@ AudioModule_GenericHandler_ModuleCommand(
         module->Descriptor == NULL || 
         module->Descriptor->Handler == NULL)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
     
@@ -530,7 +530,7 @@ AudioModule_GenericHandler_ModuleCommand(
     {
         ULONG flags = KSPROPERTY_TYPE_GET | KSPROPERTY_TYPE_BASICSUPPORT;
 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return PropertyHandler_BasicSupport(PropertyRequest, flags, VT_ILLEGAL);
     }
 
@@ -565,18 +565,18 @@ AudioModule_GenericHandler_ModuleCommand(
                                               outBuffer,
                                               &outBufferCb);
         //
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // Set the size of the returned output data, or in the case of
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // buffer overflow error, return the expected buffer length.
         //
         PropertyRequest->ValueSize = outBufferCb;
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return status;
     }
 
     PropertyRequest->ValueSize = 0;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_INVALID_DEVICE_REQUEST;
 } // AudioModule_GenericHandler_ModuleCommand
 
@@ -590,14 +590,14 @@ AudioModule_GenericHandler_ModuleNotificationDeviceId(
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
     // Basic parameter validation.
     //
     if (NotificationDeviceId == NULL)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_DEVICE_REQUEST;
     }
 
@@ -606,7 +606,7 @@ AudioModule_GenericHandler_ModuleNotificationDeviceId(
     {
         ULONG flags = KSPROPERTY_TYPE_GET | KSPROPERTY_TYPE_BASICSUPPORT;
 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return PropertyHandler_BasicSupport(PropertyRequest, flags, VT_ILLEGAL);
     }
 
@@ -619,12 +619,12 @@ AudioModule_GenericHandler_ModuleNotificationDeviceId(
         if (PropertyRequest->ValueSize == 0)
         {
             PropertyRequest->ValueSize = cbMinSize;
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_BUFFER_OVERFLOW;
         }
         if (PropertyRequest->ValueSize < cbMinSize)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_BUFFER_TOO_SMALL;
         }
         else
@@ -632,12 +632,12 @@ AudioModule_GenericHandler_ModuleNotificationDeviceId(
             *dataPtr = *NotificationDeviceId;
             PropertyRequest->ValueSize = cbMinSize;
 
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_SUCCESS;
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_INVALID_DEVICE_REQUEST;
 }
 
@@ -655,7 +655,7 @@ AudioModule_SendNotification(
     
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // Allocate a notification buffer.
     status = PortNotifications->AllocNotificationBuffer(PagedPool,

--- a/sysvad/EndpointsCommon/MiniportAudioEngineNode.cpp
+++ b/sysvad/EndpointsCommon/MiniportAudioEngineNode.cpp
@@ -72,7 +72,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetAudioEngineDescriptor(_In_ ULONG _ul
     NTSTATUS ntStatus = STATUS_UNSUCCESSFUL;
 
     ASSERT (_pAudioEngineDescriptor);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     // In this sample driver, only one single engine node is exposed in its wave filter
     if (_ulNodeId == KSNODE_WAVE_AUDIO_ENGINE)
     {
@@ -85,7 +85,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetAudioEngineDescriptor(_In_ ULONG _ul
     {
         ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     }
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -99,7 +99,7 @@ Description:
 Parameters
     
     _In_ _ulNodeId: node id for the target audio engine node
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     _Out_ pbEnable: a pointer to a BOOL value for receieving the returned GFX state
 
 Return Value:
@@ -110,19 +110,19 @@ Called at PASSIVE_LEVEL
 
 Remarks
     The global operations (on the device stream) inside HW Audio Engine (such as src, dsp, and other special effects) are hidden from the software audio stack.
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 So, the driver should return TRUE if any one of the effects is on and returns FALSE when all the opertations are off.
 -------------------------------------------------------------------------------------------------------------------------*/
 STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetGfxState(_In_ ULONG _ulNodeId, _Out_ BOOL *_pbEnable)
 {
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     UNREFERENCED_PARAMETER(_ulNodeId);
 
     *_pbEnable = m_bGfxEnabled;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -153,13 +153,13 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::SetGfxState(_In_ ULONG _ulNodeId, _In_ 
 {
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     UNREFERENCED_PARAMETER(_ulNodeId);
     
     // see above comments for appropriate enabling/disabling opertations on the HW Audio Engine
     m_bGfxEnabled = _bEnable;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -176,7 +176,7 @@ Parameters:
 
         _In_ _ulNodeId: node id for the target audio engine node
         _In_ eEngineFormatType: format target to indicate which format size is being asked
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ pulFormatSize: a pointer to a ULONG variable for receiving returned szize information
 
 Return Value:
@@ -198,7 +198,7 @@ NTSTATUS CMiniportWaveRT::GetEngineFormatSize
     PAGED_CODE ();
     NTSTATUS ntStatus = STATUS_SUCCESS;
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     ASSERT (_pulFormatSize);
 
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
@@ -206,15 +206,15 @@ NTSTATUS CMiniportWaveRT::GetEngineFormatSize
     switch (_formatType)
     {
         case eMixFormat:
-            DPF_ENTER(("[%s]", __FUNCTION__));
+            DPF_ENTER();
             *_pulFormatSize = sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE);
             break;
         case eDeviceFormat:
-            DPF_ENTER(("[%s]", __FUNCTION__));
+            DPF_ENTER();
             *_pulFormatSize = sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE);
             break;
         case eSupportedDeviceFormats:
-            DPF_ENTER(("[%s]", __FUNCTION__));
+            DPF_ENTER();
             *_pulFormatSize = sizeof(KSMULTIPLE_ITEM) + sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE) * GetAudioEngineSupportedDeviceFormats(NULL);
             break;
         default:
@@ -222,7 +222,7 @@ NTSTATUS CMiniportWaveRT::GetEngineFormatSize
             break;
     }
 Exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -231,7 +231,7 @@ IMiniportAudioEngineNode::GetMixFormat
  
 Decscription:
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     GetMixFormat returns the current mix format used by the HW Audio Engine
 
 Parameters:
@@ -258,7 +258,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetMixFormat(_In_  ULONG    _ulNodeId, 
 
     ASSERT (_pFormat);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
     IF_TRUE_ACTION_JUMP(_ulBufferSize < sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE), ntStatus = STATUS_BUFFER_TOO_SMALL, Exit);
@@ -272,7 +272,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetMixFormat(_In_  ULONG    _ulNodeId, 
     ntStatus = STATUS_SUCCESS;
 
 Exit:    
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 /*-----------------------------------------------------------------------------
@@ -280,7 +280,7 @@ IMiniportAudioEngineNode::GetDeviceFormat
  
 Decscription:
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     GetDeviceFormat returns the current device format used by the HW Audio Engine
 
 Parameters:
@@ -308,7 +308,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetDeviceFormat(_In_ ULONG _ulNodeId, _
 
     ASSERT (_pFormat);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
     IF_TRUE_ACTION_JUMP(_ulBufferSize < sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE), ntStatus = STATUS_BUFFER_TOO_SMALL, Exit);
 #pragma warning(push)
@@ -321,7 +321,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetDeviceFormat(_In_ ULONG _ulNodeId, _
     ntStatus = STATUS_SUCCESS;
 
 Exit:    
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -356,7 +356,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::SetDeviceFormat(_In_  ULONG _ulNodeId, 
 
     ASSERT (_pFormat);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
     IF_TRUE_ACTION_JUMP(_ulBufferSize < sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE), ntStatus = STATUS_BUFFER_TOO_SMALL, Exit);
 
@@ -364,7 +364,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::SetDeviceFormat(_In_  ULONG _ulNodeId, 
     ntStatus = STATUS_SUCCESS;
 
 Exit:    
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -399,7 +399,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetSupportedDeviceFormats(_In_  ULONG _
 
     ASSERT(_pFormat);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
 
     cDeviceFormats = GetAudioEngineSupportedDeviceFormats(&pDeviceFormats);
@@ -416,7 +416,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetSupportedDeviceFormats(_In_  ULONG _
     ntStatus = STATUS_SUCCESS;
 
 Exit:    
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 /*-----------------------------------------------------------------------------
@@ -432,7 +432,7 @@ Parameters:
 
         _In_ _ulNodeId: node id for the target audio engine node
         _In_ _targetType:  the query target (volume. mute, or peak meter)
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pulChannelCount: a pointer to a UINT32 variable for receiving returned channel count information
 
 Return Value:
@@ -457,7 +457,7 @@ NTSTATUS CMiniportWaveRT::GetDeviceChannelCount
     PAGED_CODE ();
     ASSERT(_pulChannelCount);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
 
@@ -477,7 +477,7 @@ NTSTATUS CMiniportWaveRT::GetDeviceChannelCount
             break;
     }
 Exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -494,7 +494,7 @@ Parameters:
 
         _In_ _ulNodeId: node id for the target audio engine node
         _In_ _targetType:  the query target (volume. mute, or peak meter)
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pKsPropMembHead: a pointer to a PKSPROPERTY_STEPPING_LONG variable for receiving returned channel count information
         _In_ ulBufferSize: a pointer to a ULONG variable that has the size of the buffer pointed by _pKsPropMembHead
 
@@ -513,7 +513,7 @@ NTSTATUS CMiniportWaveRT::GetDeviceAttributeSteppings(_In_  ULONG _ulNodeId, _In
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
 
     switch (_targetType)
@@ -532,7 +532,7 @@ NTSTATUS CMiniportWaveRT::GetDeviceAttributeSteppings(_In_  ULONG _ulNodeId, _In
             break;
     }
 Exit:
-     DPF_EXIT(("[%s]", __FUNCTION__));
+     DPF_EXIT();
      return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -548,7 +548,7 @@ Parameters:
 
         _In_ _ulNodeId: node id for the target audio engine node
         _In_ _uiChannel:  the target channel for this GET volume operation
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pVolume: a pointer to a LONG variable for receiving returned information
 
 Return Value:
@@ -566,13 +566,13 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetDeviceChannelVolume(_In_  ULONG _ulN
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
 
     ntStatus = GetChannelVolume(_uiChannel, _pVolume);
 
 Exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -606,13 +606,13 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::SetDeviceChannelVolume(_In_  ULONG _ulN
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
 
     ntStatus = SetChannelVolume(_uiChannel, _Volume);
 
 Exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -629,7 +629,7 @@ Parameters:
 
         _In_ _ulNodeId: node id for the target audio engine node
         _In_ _uiChannel:  the target channel for this GET volume operation
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pPeakMeterValue: a pointer to a LONG variable for receiving returned information
 
 Return Value:
@@ -646,12 +646,12 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetDeviceChannelPeakMeter(_In_  ULONG _
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
     ntStatus = GetChannelPeakMeter(_uiChannel, _pPeakMeterValue);
 
 Exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 /*-----------------------------------------------------------------------------
@@ -666,7 +666,7 @@ Parameters:
 
         _In_ _ulNodeId: node id for the target audio engine node
         _In_ _uiChannel:  the target channel for this GET volume operation
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pbMute: a pointer to a BOOL variable for receiving returned information
 
 Return Value:
@@ -685,12 +685,12 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetDeviceChannelMute(_In_  ULONG _ulNod
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
 
     ntStatus = GetChannelMute(_uiChannel, _pbMute);
 Exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -724,13 +724,13 @@ NTSTATUS CMiniportWaveRT::SetDeviceChannelMute(_In_  ULONG _ulNodeId, _In_ UINT3
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     IF_TRUE_ACTION_JUMP(_ulNodeId != KSNODE_WAVE_AUDIO_ENGINE, ntStatus = STATUS_INVALID_DEVICE_REQUEST, Exit);
 
     ntStatus = SetChannelMute(_uiChannel, _bMute);
 
 Exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -771,12 +771,12 @@ NTSTATUS CMiniportWaveRT::GetBufferSizeRange(_In_  ULONG _ulNodeId, _In_ KSDATAF
     UNREFERENCED_PARAMETER(_ulNodeId);
     ASSERT(_pBufferSizeRange);
     ASSERT(_pKsDataFormatWfx);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     _pBufferSizeRange->MinBufferBytes = (_pKsDataFormatWfx->WaveFormatEx.nAvgBytesPerSec * MIN_BUFFER_DURATION_MS) / MS_PER_SEC;
     _pBufferSizeRange->MaxBufferBytes = (_pKsDataFormatWfx->WaveFormatEx.nAvgBytesPerSec * MAX_BUFFER_DURATION_MS) / MS_PER_SEC;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -790,7 +790,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeChannelCount(_Out_  UINT32 *_pulChannelCount)
     PAGED_CODE ();
     ASSERT (_pulChannelCount);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsVolumeSupported(m_DeviceType))
@@ -806,7 +806,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeChannelCount(_Out_  UINT32 *_pulChannelCount)
     {
         *_pulChannelCount = m_DeviceMaxChannels;
     }
-     DPF_EXIT(("[%s]", __FUNCTION__));
+     DPF_EXIT();
      return ntStatus;
 }
 
@@ -816,7 +816,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeSteppings(_Out_writes_bytes_(_ui32DataSize) P
     PAGED_CODE ();
     UINT32 ulChannelCount = _ui32DataSize / sizeof(KSPROPERTY_STEPPING_LONG);
     ASSERT (_pKsPropStepLong);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsVolumeSupported(m_DeviceType))
@@ -833,7 +833,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeSteppings(_Out_writes_bytes_(_ui32DataSize) P
 
         if (ulChannelCount > pMembers->MembersCount)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_PARAMETER;
         }
 
@@ -850,7 +850,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeSteppings(_Out_writes_bytes_(_ui32DataSize) P
         ASSERT(ulChannelCount <= m_DeviceMaxChannels);
         if (ulChannelCount > m_DeviceMaxChannels)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_PARAMETER;
         }
 
@@ -861,7 +861,7 @@ NTSTATUS CMiniportWaveRT::GetVolumeSteppings(_Out_writes_bytes_(_ui32DataSize) P
             _pKsPropStepLong[i].Bounds.SignedMinimum = VOLUME_SIGNED_MINIMUM;
         }
     }
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -882,7 +882,7 @@ NTSTATUS CMiniportWaveRT::GetChannelVolume(_In_  UINT32 _uiChannel, _Out_ LONG *
 {
     PAGED_CODE ();
     ASSERT (_pVolume);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS status = STATUS_SUCCESS;
 
@@ -905,19 +905,19 @@ NTSTATUS CMiniportWaveRT::GetChannelVolume(_In_  UINT32 _uiChannel, _Out_ LONG *
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 #pragma code_seg("PAGE")
 NTSTATUS CMiniportWaveRT::SetChannelVolume(_In_  UINT32 _uiChannel, _In_  LONG _Volume)
 {
     PAGED_CODE ();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsVolumeSupported(m_DeviceType))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return m_pSidebandDevice->SetVolume(m_DeviceType, _uiChannel, _Volume);
     }
     else
@@ -945,7 +945,7 @@ NTSTATUS CMiniportWaveRT::SetChannelVolume(_In_  UINT32 _uiChannel, _In_  LONG _
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 ///- metering
@@ -956,9 +956,9 @@ NTSTATUS CMiniportWaveRT::GetPeakMeterChannelCount(_Out_  UINT32 *_pulChannelCou
     PAGED_CODE ();
     ASSERT (_pulChannelCount);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     *_pulChannelCount = m_DeviceMaxChannels;
-     DPF_EXIT(("[%s]", __FUNCTION__));
+     DPF_EXIT();
      return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -968,13 +968,13 @@ NTSTATUS CMiniportWaveRT::GetPeakMeterSteppings(_Out_writes_bytes_(_ui32DataSize
     UINT32 ulChannelCount = _ui32DataSize / sizeof(KSPROPERTY_STEPPING_LONG);
 
     ASSERT (_pKsPropStepLong);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(ulChannelCount <= m_DeviceMaxChannels);
 
     if (ulChannelCount > m_DeviceMaxChannels)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -984,7 +984,7 @@ NTSTATUS CMiniportWaveRT::GetPeakMeterSteppings(_Out_writes_bytes_(_ui32DataSize
         _pKsPropStepLong[i].Bounds.SignedMaximum = PEAKMETER_SIGNED_MAXIMUM;
         _pKsPropStepLong[i].Bounds.SignedMinimum = PEAKMETER_SIGNED_MINIMUM;
     }
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -992,13 +992,13 @@ NTSTATUS CMiniportWaveRT::GetChannelPeakMeter(_In_  UINT32 _uiChannel, _Out_  LO
 {
     PAGED_CODE ();
     ASSERT (_plPeakMeter);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(_uiChannel < m_DeviceMaxChannels);
 
     if (_uiChannel >= m_DeviceMaxChannels)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -1012,7 +1012,7 @@ NTSTATUS CMiniportWaveRT::GetChannelPeakMeter(_In_  UINT32 _uiChannel, _Out_  LO
     }
     //*_plPeakMeter = m_plPeakMeter[lChannel];
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 // mute
@@ -1023,7 +1023,7 @@ NTSTATUS CMiniportWaveRT::GetMuteChannelCount(_Out_  UINT32 *_pulChannelCount)
     PAGED_CODE ();
     ASSERT (_pulChannelCount);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsMuteSupported(m_DeviceType))
@@ -1039,7 +1039,7 @@ NTSTATUS CMiniportWaveRT::GetMuteChannelCount(_Out_  UINT32 *_pulChannelCount)
     {
         *_pulChannelCount = m_DeviceMaxChannels;
     }
-     DPF_EXIT(("[%s]", __FUNCTION__));
+     DPF_EXIT();
      return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -1049,7 +1049,7 @@ NTSTATUS CMiniportWaveRT::GetMuteSteppings(_Out_writes_bytes_(_ui32DataSize)  PK
     UINT32 ulChannelCount = _ui32DataSize / sizeof(KSPROPERTY_STEPPING_LONG);
 
     ASSERT (_pKsPropStepLong);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsMuteSupported(m_DeviceType))
@@ -1066,7 +1066,7 @@ NTSTATUS CMiniportWaveRT::GetMuteSteppings(_Out_writes_bytes_(_ui32DataSize)  PK
 
         if (ulChannelCount > pMembers->MembersCount)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_PARAMETER;
         }
 
@@ -1085,7 +1085,7 @@ NTSTATUS CMiniportWaveRT::GetMuteSteppings(_Out_writes_bytes_(_ui32DataSize)  PK
 
         if (ulChannelCount > m_DeviceMaxChannels)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_PARAMETER;
         }
 
@@ -1096,7 +1096,7 @@ NTSTATUS CMiniportWaveRT::GetMuteSteppings(_Out_writes_bytes_(_ui32DataSize)  PK
             _pKsPropStepLong[i].Bounds.SignedMinimum = FALSE;
         }
     }
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -1104,7 +1104,7 @@ NTSTATUS CMiniportWaveRT::GetChannelMute(_In_  UINT32 _uiChannel, _Out_  BOOL *_
 {
     PAGED_CODE ();
     ASSERT (_pbMute);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsMuteSupported(m_DeviceType))
@@ -1125,19 +1125,19 @@ NTSTATUS CMiniportWaveRT::GetChannelMute(_In_  UINT32 _uiChannel, _Out_  BOOL *_
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
 NTSTATUS CMiniportWaveRT::SetChannelMute(_In_  UINT32 _uiChannel, _In_  BOOL _bMute)
 {
     PAGED_CODE ();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
     if (IsSidebandDevice() && m_pSidebandDevice->IsMuteSupported(m_DeviceType))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return m_pSidebandDevice->SetMute(m_DeviceType, _uiChannel, _bMute);
     }
 #endif
@@ -1156,7 +1156,7 @@ NTSTATUS CMiniportWaveRT::SetChannelMute(_In_  UINT32 _uiChannel, _In_  BOOL _bM
         m_pbMuted[_uiChannel] = _bMute;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -1187,7 +1187,7 @@ Return Value:
 --*/
 {
     PAGED_CODE ();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     NTSTATUS    ntStatus    = STATUS_SUCCESS;
 
@@ -1227,7 +1227,7 @@ Return Value:
     }
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 

--- a/sysvad/EndpointsCommon/MiniportStreamAudioEngineNode.cpp
+++ b/sysvad/EndpointsCommon/MiniportStreamAudioEngineNode.cpp
@@ -48,10 +48,10 @@ NTSTATUS CMiniportWaveRTStream::GetLfxState(_Out_ BOOL *_pbEnable)
 {
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     *_pbEnable = m_bLfxEnabled;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -81,11 +81,11 @@ NTSTATUS CMiniportWaveRTStream::SetLfxState(_In_ BOOL _bEnable)
 {
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     UNREFERENCED_PARAMETER(_bEnable);
     m_bLfxEnabled = _bEnable;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -100,7 +100,7 @@ Decscription:
 Parameters:
 
         _In_ _uiChannel:  the target channel for this GET volume operation
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pVolume: a pointer to a LONG variable for receiving returned information
 
 Return Value:
@@ -116,11 +116,11 @@ NTSTATUS CMiniportWaveRTStream::GetStreamChannelVolume(_In_ UINT32 _uiChannel, _
 {
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     *_pVolume = m_plVolumeLevel[_uiChannel];
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -135,7 +135,7 @@ Decscription:
 Parameters:
 
         _In_ _uiChannel:  the target channel for this GET volume operation
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pbMute: a pointer to a BOOL variable for receiving returned information
 
 Return Value:
@@ -154,10 +154,10 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRTStream::GetStreamChannelMute(_In_ UINT32 
     PAGED_CODE ();
     ASSERT (_pbMute);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     ntStatus = GetChannelMute(_uiChannel, _pbMute);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -173,7 +173,7 @@ Decscription:
 Parameters:
 
         _In_ _targetType:  the query target (volume. mute, or peak meter)
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pKsPropMembHead: a pointer to a PKSPROPERTY_STEPPING_LONG variable for receiving returned channel count information
         _In_ ulBufferSize: a pointer to a ULONG variable that has the size of the buffer pointed by _pKsPropMembHead
 
@@ -192,7 +192,7 @@ NTSTATUS CMiniportWaveRTStream::GetStreamAttributeSteppings(_In_  eChannelTarget
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     switch (_targetType)
     {
@@ -209,7 +209,7 @@ NTSTATUS CMiniportWaveRTStream::GetStreamAttributeSteppings(_In_  eChannelTarget
             ntStatus = STATUS_INVALID_DEVICE_REQUEST;
             break;
     }
-     DPF_EXIT(("[%s]", __FUNCTION__));
+     DPF_EXIT();
      return ntStatus;
 
 }
@@ -252,7 +252,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRTStream::SetStreamChannelVolume
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // Snap the volume level to our range of steppings.
     LONG lVolume = VOLUME_NORMALIZE_IN_RANGE(TargetVolume); 
@@ -270,7 +270,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRTStream::SetStreamChannelVolume
         ntStatus = SetChannelVolume(Channel, lVolume);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -286,7 +286,7 @@ Decscription:
 Parameters:
 
         _In_ _uiChannel:  the target channel for this GET peak meter operation
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     _Out_ _pPeakMeterValue: a pointer to a LONG variable for receiving returned information
 
 Return Value:
@@ -304,11 +304,11 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRTStream::GetStreamChannelPeakMeter(_In_ UI
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ntStatus = GetChannelPeakMeter(_uiChannel, _pPeakMeterValue);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -341,7 +341,7 @@ NTSTATUS CMiniportWaveRTStream::SetStreamChannelMute(_In_ UINT32 _uiChannel, _In
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     // If Channel is ALL_CHANNELS_ID, then set the mute info on all channels
     if ( ALL_CHANNELS_ID == _uiChannel )
@@ -356,7 +356,7 @@ NTSTATUS CMiniportWaveRTStream::SetStreamChannelMute(_In_ UINT32 _uiChannel, _In
         ntStatus = SetChannelMute(_uiChannel, _bMute);
     }
  
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 //presentation
@@ -371,7 +371,7 @@ Decscription:
 
 Parameters:
 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ pPresentationPosition: a pointer to a KSAUDIO_PRESENTATION_POSITION variable for receiving returned information
 
 Return Value:
@@ -389,11 +389,11 @@ NTSTATUS CMiniportWaveRTStream::GetStreamPresentationPosition(_Out_ KSAUDIO_PRES
 
     PAGED_CODE ();
     ASSERT(_pPresentationPosition);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ntStatus = GetPresentationPosition(_pPresentationPosition);
  
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 //StreamCurrentWritePosition
@@ -434,11 +434,11 @@ NTSTATUS CMiniportWaveRTStream::SetStreamCurrentWritePosition(_In_ ULONG _ulCurr
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
 
     PAGED_CODE ();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ntStatus = SetCurrentWritePosition(_ulCurrentWritePosition);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -452,7 +452,7 @@ Decscription:
 
 Parameters:
 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ pullLinearBufferPosition: a pointer to a ULONGLONG variable for receiving returned information
 
 
@@ -463,7 +463,7 @@ Return Value:
 Called at PASSIVE_LEVEL
 
 Remarks
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 The returned  value is the number of bytes that the DMA has fetched from the audio buffer since the beginning of the stream
 -------------------------------------------------------------------------------------------------------------------------*/
 NTSTATUS CMiniportWaveRTStream::GetStreamLinearBufferPosition(_Out_ ULONGLONG *_pullLinearBufferPosition)
@@ -472,11 +472,11 @@ NTSTATUS CMiniportWaveRTStream::GetStreamLinearBufferPosition(_Out_ ULONGLONG *_
 
     PAGED_CODE ();
     ASSERT(_pullLinearBufferPosition);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ntStatus = GetPositions(_pullLinearBufferPosition, NULL, NULL);
  
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 //SetStreamLoopbackProtection
@@ -509,14 +509,14 @@ NTSTATUS CMiniportWaveRTStream::SetStreamLoopbackProtection(_In_ CONSTRICTOR_OPT
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
 
     PAGED_CODE ();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
     // Miniport driver mutes/unmutes the loopback here.
     // 
     ntStatus = m_pMiniport->SetLoopbackProtection(protectionOption);
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 #pragma code_seg("PAGE")
@@ -532,7 +532,7 @@ Decscription:
 Parameters:
 
         _In_ _targetType:  the query target (volume, mute, or peak meter)
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         _Out_ _pulChannelCount: a pointer to a UINT32 variable for receiving returned channel count information
 
 Return Value:
@@ -550,7 +550,7 @@ NTSTATUS CMiniportWaveRTStream::GetStreamChannelCount(_In_  eChannelTargetType  
 
     PAGED_CODE ();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     switch (_targetType)
     {
@@ -568,7 +568,7 @@ NTSTATUS CMiniportWaveRTStream::GetStreamChannelCount(_In_  eChannelTargetType  
             break;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -581,14 +581,14 @@ NTSTATUS CMiniportWaveRTStream::GetVolumeChannelCount(_Out_ UINT32 *_puiChannelC
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(_puiChannelCount);
     ASSERT(m_pWfExt);
 
     NTSTATUS ntStatus = STATUS_SUCCESS;
     *_puiChannelCount = m_pWfExt->Format.nChannels;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -598,11 +598,11 @@ NTSTATUS CMiniportWaveRTStream::GetVolumeSteppings(_Out_writes_bytes_(_ui32DataS
     PAGED_CODE ();
     UINT32 ulChannelCount = _ui32DataSize / sizeof(KSPROPERTY_STEPPING_LONG);
     ASSERT (_pKsPropStepLong);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     if (ulChannelCount != m_pWfExt->Format.nChannels)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -613,7 +613,7 @@ NTSTATUS CMiniportWaveRTStream::GetVolumeSteppings(_Out_writes_bytes_(_ui32DataS
         _pKsPropStepLong[i].Bounds.SignedMinimum = VOLUME_SIGNED_MINIMUM;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -621,22 +621,22 @@ NTSTATUS CMiniportWaveRTStream::GetChannelVolume(_In_  UINT32 _uiChannel, _Out_ 
 {
     PAGED_CODE ();
     ASSERT (_pVolume);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     *_pVolume = m_plVolumeLevel[_uiChannel];
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
 NTSTATUS CMiniportWaveRTStream::SetChannelVolume(_In_  UINT32 _uiChannel, _In_  LONG _Volume)
 {
     PAGED_CODE ();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     m_plVolumeLevel[_uiChannel] = _Volume;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 ///- metering
@@ -645,14 +645,14 @@ NTSTATUS CMiniportWaveRTStream::GetPeakMeterChannelCount(_Out_ UINT32 *puiChanne
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(puiChannelCount);
     ASSERT(m_pWfExt);
 
     NTSTATUS ntStatus = STATUS_SUCCESS;
     *puiChannelCount = m_pWfExt->Format.nChannels;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -663,11 +663,11 @@ NTSTATUS CMiniportWaveRTStream::GetPeakMeterSteppings(_Out_writes_bytes_(_ui32Da
     UINT32 ulChannelCount = _ui32DataSize / sizeof(KSPROPERTY_STEPPING_LONG);
 
     ASSERT (_pKsPropStepLong);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     if (ulChannelCount != m_pWfExt->Format.nChannels)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -678,7 +678,7 @@ NTSTATUS CMiniportWaveRTStream::GetPeakMeterSteppings(_Out_writes_bytes_(_ui32Da
         _pKsPropStepLong[i].Bounds.SignedMinimum = PEAKMETER_SIGNED_MINIMUM;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -687,11 +687,11 @@ NTSTATUS CMiniportWaveRTStream::GetChannelPeakMeter(_In_  UINT32 _uiChannel, _Ou
     PAGED_CODE ();
     ASSERT (_plPeakMeter);
     UNREFERENCED_PARAMETER(_uiChannel);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     *_plPeakMeter = PEAKMETER_NORMALIZE_IN_RANGE(PEAKMETER_SIGNED_MAXIMUM / 2);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -702,14 +702,14 @@ NTSTATUS CMiniportWaveRTStream::GetMuteChannelCount(_Out_ UINT32 *puiChannelCoun
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(puiChannelCount);
     ASSERT(m_pWfExt);
 
     NTSTATUS ntStatus = STATUS_SUCCESS;
     *puiChannelCount = m_pWfExt->Format.nChannels;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -720,11 +720,11 @@ NTSTATUS CMiniportWaveRTStream::GetMuteSteppings(_Out_writes_bytes_(_ui32DataSiz
     UINT32 ulChannelCount = _ui32DataSize / sizeof(KSPROPERTY_STEPPING_LONG);
 
     ASSERT (_pKsPropStepLong);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     if (ulChannelCount != m_pWfExt->Format.nChannels)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -735,7 +735,7 @@ NTSTATUS CMiniportWaveRTStream::GetMuteSteppings(_Out_writes_bytes_(_ui32DataSiz
         _pKsPropStepLong[i].Bounds.SignedMinimum = FALSE;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
@@ -743,21 +743,21 @@ NTSTATUS CMiniportWaveRTStream::GetChannelMute(_In_  UINT32 _uiChannel, _Out_  B
 {
     PAGED_CODE ();
     ASSERT (_pbMute);
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     *_pbMute = m_pbMuted[_uiChannel];
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 #pragma code_seg("PAGE")
 NTSTATUS CMiniportWaveRTStream::SetChannelMute(_In_  UINT32 _uiChannel, _In_  BOOL _bMute)
 {
     PAGED_CODE ();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     m_pbMuted[_uiChannel] = _bMute;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 //presentation
@@ -776,7 +776,7 @@ NTSTATUS CMiniportWaveRTStream::GetPresentationPosition(_Out_  KSAUDIO_PRESENTAT
     LARGE_INTEGER timeStamp;
     PADAPTERCOMMON pAdapterComm = m_pMiniport->GetAdapterCommObj();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ULONGLONG ullLinearPosition = {0};
     ULONGLONG ullPresentationPosition = {0};
@@ -785,7 +785,7 @@ NTSTATUS CMiniportWaveRTStream::GetPresentationPosition(_Out_  KSAUDIO_PRESENTAT
     status = GetPositions(&ullLinearPosition, &ullPresentationPosition, &timeStamp);
     if (!NT_SUCCESS(status)) 
     { 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return status;
     }
 
@@ -802,14 +802,14 @@ NTSTATUS CMiniportWaveRTStream::GetPresentationPosition(_Out_  KSAUDIO_PRESENTAT
                                 m_ulCurrentWritePosition,
                                 _pPresentationPosition->u64PositionInBlocks,
                                 0);  // always zero
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
 #pragma code_seg()
 NTSTATUS CMiniportWaveRTStream::SetCurrentWritePosition(_In_  ULONG _ulCurrentWritePosition)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     NTSTATUS ntStatus;
 
@@ -836,26 +836,26 @@ NTSTATUS CMiniportWaveRTStream::SetCurrentWritePosition(_In_  ULONG _ulCurrentWr
     KeReleaseSpinLock(&m_PositionSpinLock, oldIrql);
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
 #pragma code_seg()
 NTSTATUS CMiniportWaveRTStream::SetCurrentWritePositionInternal(_In_  ULONG _ulCurrentWritePosition)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     ASSERT(m_bEoSReceived == FALSE);
 
     if (m_bEoSReceived)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_DEVICE_REQUEST;
     }
 
     if (_ulCurrentWritePosition > m_ulDmaBufferSize)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_DEVICE_REQUEST;
     }
     
@@ -895,7 +895,7 @@ NTSTATUS CMiniportWaveRTStream::SetCurrentWritePositionInternal(_In_  ULONG _ulC
     m_ulCurrentWritePosition = _ulCurrentWritePosition;
     InterlockedExchange(&m_IsCurrentWritePositionUpdated, 1);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -907,7 +907,7 @@ NTSTATUS CMiniportWaveRTStream::GetPositions(
     _Out_opt_  LARGE_INTEGER *  _pliQPCTime
     )
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS        ntStatus;
     LARGE_INTEGER   ilQPC;
@@ -952,7 +952,7 @@ NTSTATUS CMiniportWaveRTStream::GetPositions(
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
 Done:
 #endif // defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -983,14 +983,14 @@ Remarks
 NTSTATUS CMiniportWaveRTStream::SetLoopbackProtection(_In_ CONSTRICTOR_OPTION protectionOption)
 {
     PAGED_CODE ();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
     // Miniport driver mutes/unmutes the loopback here.
     // 
     m_ToneGenerator.SetMute(protectionOption == CONSTRICTOR_OPTION_MUTE);
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -1023,7 +1023,7 @@ NTSTATUS CMiniportWaveRTStream::SetLoopbackProtection(_In_ CONSTRICTOR_OPTION pr
 
 NTSTATUS CMiniportWaveRTStream::SetStreamCurrentWritePositionForLastBuffer(_In_ ULONG _ulWritePosition)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     NTSTATUS        ntStatus;
     KIRQL           oldIrql;
 
@@ -1040,7 +1040,7 @@ NTSTATUS CMiniportWaveRTStream::SetStreamCurrentWritePositionForLastBuffer(_In_ 
 
     KeReleaseSpinLock(&m_PositionSpinLock, oldIrql);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 

--- a/sysvad/EndpointsCommon/micarraytopo.cpp
+++ b/sysvad/EndpointsCommon/micarraytopo.cpp
@@ -117,8 +117,8 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
-DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_ENTER();
+DPF_EXIT();
 } // ~CMicArrayMiniportTopology
 
 //=============================================================================
@@ -251,7 +251,7 @@ Return Value:
     ASSERT(UnknownAdapter);
     ASSERT(Port_);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                    ntStatus;
 
@@ -262,7 +262,7 @@ Return Value:
             Port_
         );
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // Init
 
@@ -348,7 +348,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS    ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG       nPinId = (ULONG)-1;
@@ -501,7 +501,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -532,7 +532,7 @@ NT status code.
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS    ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG       nPinId = (ULONG)-1;
@@ -603,7 +603,7 @@ NT status code.
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -633,7 +633,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG    nPinId = (ULONG)-1;
@@ -693,7 +693,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -723,7 +723,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG    nPinId = (ULONG)-1;
@@ -783,7 +783,7 @@ Return Value:
                         // a client application can call IKsJackDescription2::GetJackDescription2 to read 
                         // the JackCapabilities flag of the KSJACK_DESCRIPTION2 structure. If this flag has
                         // the JACKDESC2_PRESENCE_DETECT_CAPABILITY bit set, it indicates that the endpoint 
-                        DPF_EXIT(("[%s]", __FUNCTION__));
+                        DPF_EXIT();
                         // does in fact support jack presence detection. In that case, the return value of 
                         // the IsConnected member can be interpreted to accurately reflect the insertion status
                         // of the jack."
@@ -801,7 +801,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -831,7 +831,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // PropertryRequest structure is filled by portcls. 
     // MajorTarget is a pointer to miniport object for miniports.
@@ -866,7 +866,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandler_TopoFilter
 
@@ -896,14 +896,14 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // PropertryRequest structure is filled by portcls. 
     // MajorTarget is a pointer to miniport object for miniports.
     //
     PCMicArrayMiniportTopology pMiniport = (PCMicArrayMiniportTopology)PropertyRequest->MajorTarget;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return pMiniport->PropertyHandlerGeneric(PropertyRequest);
 } // PropertyHandler_MicArrayTopology
 

--- a/sysvad/EndpointsCommon/mintopo.cpp
+++ b/sysvad/EndpointsCommon/mintopo.cpp
@@ -105,7 +105,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND) || defined (SYSVAD_A2DP_SIDEBAND)
     if (IsSidebandDevice())
@@ -127,7 +127,7 @@ Return Value:
 #endif // defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND) || defined(SYSVAD_A2DP_SIDEBAND)
 
 
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 } // ~CMiniportTopology
 
 //=============================================================================
@@ -263,7 +263,7 @@ Return Value:
     ASSERT(UnknownAdapter);
     ASSERT(Port_);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                    ntStatus;
 
@@ -320,7 +320,7 @@ Return Value:
 #endif  // defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND) || defined(SYSVAD_A2DP_SIDEBAND)
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // Init
 
@@ -412,7 +412,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG    nPinId = (ULONG)-1;
@@ -464,7 +464,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -501,7 +501,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG    nPinId = (ULONG)-1;
@@ -561,7 +561,7 @@ Return Value:
                         // a client application can call IKsJackDescription2::GetJackDescription2 to read 
                         // the JackCapabilities flag of the KSJACK_DESCRIPTION2 structure. If this flag has
                         // the JACKDESC2_PRESENCE_DETECT_CAPABILITY bit set, it indicates that the endpoint 
-                        DPF_EXIT(("[%s]", __FUNCTION__));
+                        DPF_EXIT();
                         // does in fact support jack presence detection. In that case, the return value of 
                         // the IsConnected member can be interpreted to accurately reflect the insertion status
                         // of the jack."
@@ -579,7 +579,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -616,7 +616,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG    nPinId = (ULONG)-1;
@@ -674,7 +674,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -705,7 +705,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS status = STATUS_INVALID_DEVICE_REQUEST;
 
@@ -714,7 +714,7 @@ Return Value:
         status = PropertyHandler_SetAudioResourceGroup(PropertyRequest);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 
@@ -728,7 +728,7 @@ CMiniportTopology::PropertyHandler_SetAudioResourceGroup
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS status = STATUS_INVALID_DEVICE_REQUEST;
 
@@ -748,7 +748,7 @@ CMiniportTopology::PropertyHandler_SetAudioResourceGroup
         PAUDIORESOURCEMANAGEMENT_RESOURCEGROUP pResourceGroup = (PAUDIORESOURCEMANAGEMENT_RESOURCEGROUP)PropertyRequest->Value;
 
         // When resource group is released, the resource group should be one that was previously assigned to the endpoint
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // Check the cached resource group, make sure the release resource group and the cached resource group are the same, if not, return failure
         if (!pResourceGroup->ResourceGroupAcquired && (wcscmp(pResourceGroup->ResourceGroupName, m_ResourceGroup.ResourceGroupName) != 0))
         {
@@ -771,7 +771,7 @@ CMiniportTopology::PropertyHandler_SetAudioResourceGroup
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 
@@ -806,7 +806,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS status = STATUS_INVALID_DEVICE_REQUEST;
     ULONG    nPinId = (ULONG)-1;
@@ -828,7 +828,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 
@@ -842,7 +842,7 @@ CMiniportTopology::PropertyHandler_AudioPostureOrientationBasicSupport
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS status = STATUS_INVALID_DEVICE_REQUEST;
 
@@ -850,7 +850,7 @@ CMiniportTopology::PropertyHandler_AudioPostureOrientationBasicSupport
 
     if (PropertyRequest->ValueSize >= sizeof(KSPROPERTY_DESCRIPTION))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // if return buffer can hold a KSPROPERTY_DESCRIPTION, return it
         //
         PKSPROPERTY_DESCRIPTION PropDesc = PKSPROPERTY_DESCRIPTION(PropertyRequest->Value);
@@ -872,7 +872,7 @@ CMiniportTopology::PropertyHandler_AudioPostureOrientationBasicSupport
     }
     else if (PropertyRequest->ValueSize >= sizeof(ULONG))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // if return buffer can hold a ULONG, return the access flags.
         *(PULONG(PropertyRequest->Value)) = KSPROPERTY_TYPE_BASICSUPPORT |
                                             KSPROPERTY_TYPE_GET |
@@ -890,7 +890,7 @@ CMiniportTopology::PropertyHandler_AudioPostureOrientationBasicSupport
         status = STATUS_BUFFER_TOO_SMALL;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 
@@ -905,7 +905,7 @@ CMiniportTopology::PropertyHandler_SetAudioPostureOrientation
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS status = STATUS_INVALID_DEVICE_REQUEST;
 
@@ -943,7 +943,7 @@ CMiniportTopology::PropertyHandler_SetAudioPostureOrientation
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 
@@ -956,13 +956,13 @@ CMiniportTopology::EvtSpeakerVolumeHandler
     _In_opt_    PVOID   Context
 )
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PCMiniportTopology This = PCMiniportTopology(Context);
     if (This == NULL)
     {
         DPF(D_ERROR, ("EvtSpeakerVolumeHandler: context is null")); 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
     
@@ -983,13 +983,13 @@ CMiniportTopology::EvtSpeakerConnectionStatusHandler
     _In_opt_    PVOID   Context
 )
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PCMiniportTopology This = PCMiniportTopology(Context);
     if (This == NULL)
     {
         DPF(D_ERROR, ("EvtSpeakerConnectionStatusHandler: context is null")); 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
     
@@ -1010,13 +1010,13 @@ CMiniportTopology::EvtMicVolumeHandler
     _In_opt_    PVOID   Context
 )
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PCMiniportTopology This = PCMiniportTopology(Context);
     if (This == NULL)
     {
         DPF(D_ERROR, ("EvtMicVolumeHandler: context is null")); 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
     
@@ -1037,13 +1037,13 @@ CMiniportTopology::EvtMicConnectionStatusHandler
     _In_opt_    PVOID   Context
 )
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PCMiniportTopology This = PCMiniportTopology(Context);
     if (This == NULL)
     {
         DPF(D_ERROR, ("EvtMicConnectionStatusHandler: context is null")); 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
     
@@ -1084,12 +1084,12 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // PropertryRequest structure is filled by portcls. 
     // MajorTarget is a pointer to miniport object for miniports.
     //
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return 
         ((PCMiniportTopology)
         (PropertyRequest->MajorTarget))->PropertyHandlerGeneric

--- a/sysvad/EndpointsCommon/minwavert.cpp
+++ b/sysvad/EndpointsCommon/minwavert.cpp
@@ -119,7 +119,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     if (m_pDeviceFormat)
     {
@@ -201,7 +201,7 @@ Return Value:
     }
 #endif // defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
 
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 } // ~CMiniportWaveRT
 
 //=============================================================================
@@ -381,7 +381,7 @@ Return Value:
     ASSERT(UnknownAdapter_);
     ASSERT(Port_);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_SUCCESS;
     size_t   size;
@@ -427,7 +427,7 @@ Return Value:
         m_pAudioModules = (AUDIOMODULE *)ExAllocatePool2(POOL_FLAG_NON_PAGED, size, MINWAVERT_POOLTAG);
         if (m_pAudioModules == NULL)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INSUFFICIENT_RESOURCES;
         }
 
@@ -453,7 +453,7 @@ Return Value:
                 
                 if (m_pAudioModules[i].Context == NULL)
                 {
-                    DPF_EXIT(("[%s]", __FUNCTION__));
+                    DPF_EXIT();
                     return STATUS_INSUFFICIENT_RESOURCES;
                 }
             }
@@ -474,7 +474,7 @@ Return Value:
                 if (!NT_SUCCESS(ntStatus))
                 {
                     ASSERT(FALSE);
-                    DPF_EXIT(("[%s]", __FUNCTION__));
+                    DPF_EXIT();
                     return ntStatus;
                 }
             }
@@ -488,7 +488,7 @@ Return Value:
     {
         if (m_ulMaxSystemStreams == 0 )
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_DEVICE_STATE;
         }
             
@@ -497,7 +497,7 @@ Return Value:
         m_SystemStreams = (PCMiniportWaveRTStream *)ExAllocatePool2(POOL_FLAG_NON_PAGED, size, MINWAVERT_POOLTAG);
         if (m_SystemStreams == NULL)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INSUFFICIENT_RESOURCES;
         }
 
@@ -505,7 +505,7 @@ Return Value:
         {
             if (m_ulMaxLoopbackStreams == 0)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INVALID_DEVICE_STATE;
             }
 
@@ -514,7 +514,7 @@ Return Value:
             m_LoopbackStreams = (PCMiniportWaveRTStream *)ExAllocatePool2(POOL_FLAG_NON_PAGED, size, MINWAVERT_POOLTAG);
             if (m_LoopbackStreams == NULL)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INSUFFICIENT_RESOURCES;
             }
         }
@@ -526,7 +526,7 @@ Return Value:
 
             if (m_ulMaxOffloadStreams == 0)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INVALID_DEVICE_STATE;
             }
             
@@ -535,7 +535,7 @@ Return Value:
             m_OffloadStreams = (PCMiniportWaveRTStream *)ExAllocatePool2(POOL_FLAG_NON_PAGED, size, MINWAVERT_POOLTAG);
             if (m_OffloadStreams == NULL)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INSUFFICIENT_RESOURCES;
             }
 
@@ -543,7 +543,7 @@ Return Value:
             m_pDeviceFormat = (PKSDATAFORMAT_WAVEFORMATEXTENSIBLE)ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE), MINWAVERT_POOLTAG);
             if (m_pDeviceFormat == NULL)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INSUFFICIENT_RESOURCES;
             }
 
@@ -551,7 +551,7 @@ Return Value:
 
             if (numDeviceFormats < 1)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_UNSUCCESSFUL;
             }
             RtlCopyMemory((PVOID)(m_pDeviceFormat), (PVOID)(pDeviceFormats), sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE));
@@ -559,7 +559,7 @@ Return Value:
             m_pMixFormat = (PKSDATAFORMAT_WAVEFORMATEXTENSIBLE)ExAllocatePool2(POOL_FLAG_NON_PAGED, sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE), MINWAVERT_POOLTAG);
             if (m_pMixFormat == NULL)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INSUFFICIENT_RESOURCES;
             }
             m_pMixFormat->DataFormat.FormatSize = sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE);
@@ -585,21 +585,21 @@ Return Value:
             m_pbMuted = (PBOOL)ExAllocatePool2(POOL_FLAG_NON_PAGED, m_DeviceMaxChannels * sizeof(BOOL), MINWAVERT_POOLTAG);
             if (m_pbMuted == NULL)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INSUFFICIENT_RESOURCES;
             }
 
             m_plVolumeLevel = (PLONG)ExAllocatePool2(POOL_FLAG_NON_PAGED, m_DeviceMaxChannels * sizeof(LONG), MINWAVERT_POOLTAG);
             if (m_plVolumeLevel == NULL)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INSUFFICIENT_RESOURCES;
             }
 
             m_plPeakMeter = (PLONG)ExAllocatePool2(POOL_FLAG_NON_PAGED, m_DeviceMaxChannels * sizeof(LONG), MINWAVERT_POOLTAG);
             if (m_plPeakMeter == NULL)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INSUFFICIENT_RESOURCES;
             }
         }
@@ -640,7 +640,7 @@ Return Value:
     }
 #endif  // #ifdef SYSVAD_BTH_BYPASS
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // Init
 
@@ -686,7 +686,7 @@ Return Value:
     ASSERT(OutStream);
     ASSERT(DataFormat);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                    ntStatus = STATUS_SUCCESS;
     PCMiniportWaveRTStream      stream = NULL;
@@ -764,7 +764,7 @@ Return Value:
         stream->Release();
     }
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // NewStream
 
@@ -846,7 +846,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetDeviceDescription(_Out_ PDEVICE_DESC
 
     ASSERT (DmaDeviceDescription);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     RtlZeroMemory (DmaDeviceDescription, sizeof (DEVICE_DESCRIPTION));
 
@@ -860,7 +860,7 @@ STDMETHODIMP_(NTSTATUS) CMiniportWaveRT::GetDeviceDescription(_Out_ PDEVICE_DESC
     DmaDeviceDescription->InterfaceType = PCIBus;
     DmaDeviceDescription->MaximumLength = 0xFFFFFFFF;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -889,7 +889,7 @@ CMiniportWaveRT::GetModes
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                ntStatus    = STATUS_INVALID_PARAMETER;
     ULONG                   numModes    = 0;
@@ -939,7 +939,7 @@ CMiniportWaveRT::GetModes
 
 Done:  
     DPF(4, ("return statue:(0x%08x)\n",ntStatus)); 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -954,7 +954,7 @@ CMiniportWaveRT::ValidateStreamCreate
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_NOT_SUPPORTED;
 
@@ -985,7 +985,7 @@ CMiniportWaveRT::ValidateStreamCreate
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -1021,7 +1021,7 @@ _Use_decl_annotations_
 ULONG CMiniportWaveRT::GetPinSupportedDeviceFormats(_In_ ULONG PinId, _Outptr_opt_result_buffer_(return) KSDATAFORMAT_WAVEFORMATEXTENSIBLE **ppFormats)
 {
     PPIN_DEVICE_FORMATS_AND_MODES pDeviceFormatsAndModes = NULL;
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
 
     AcquireFormatsAndModesLock();
 
@@ -1037,7 +1037,7 @@ ULONG CMiniportWaveRT::GetPinSupportedDeviceFormats(_In_ ULONG PinId, _Outptr_op
 
     ReleaseFormatsAndModesLock();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return pDeviceFormatsAndModes[PinId].WaveFormatsCount;
 }
 
@@ -1058,7 +1058,7 @@ ULONG CMiniportWaveRT::GetPinSupportedDeviceFormats(_In_ ULONG PinId, _Outptr_op
 _Use_decl_annotations_
 ULONG CMiniportWaveRT::GetAudioEngineSupportedDeviceFormats(_Outptr_opt_result_buffer_(return) KSDATAFORMAT_WAVEFORMATEXTENSIBLE **ppFormats)
 {
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     ULONG i;
     PPIN_DEVICE_FORMATS_AND_MODES pDeviceFormatsAndModes = NULL;
 
@@ -1085,7 +1085,7 @@ ULONG CMiniportWaveRT::GetAudioEngineSupportedDeviceFormats(_Outptr_opt_result_b
     }
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return pDeviceFormatsAndModes[i].WaveFormatsCount;
 }
 
@@ -1105,7 +1105,7 @@ ULONG CMiniportWaveRT::GetAudioEngineSupportedDeviceFormats(_Outptr_opt_result_b
 _Use_decl_annotations_
 ULONG CMiniportWaveRT::GetPinSupportedDeviceModes(_In_ ULONG PinId, _Outptr_opt_result_buffer_(return) _On_failure_(_Deref_post_null_) MODE_AND_DEFAULT_FORMAT **ppModes)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     PMODE_AND_DEFAULT_FORMAT modes;
     ULONG numModes;
 
@@ -1152,98 +1152,98 @@ ULONG CMiniportWaveRT::GetPinSupportedDeviceModes(_In_ ULONG PinId, _Outptr_opt_
     }
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return numModes;
 }
 
 #pragma code_seg()
 BOOL CMiniportWaveRT::IsSystemCapturePin(ULONG nPinId)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     AcquireFormatsAndModesLock();
 
     PINTYPE pinType = m_DeviceFormatsAndModes[nPinId].PinType;
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return (pinType == SystemCapturePin);
 }
 
 #pragma code_seg()
 BOOL CMiniportWaveRT::IsCellularBiDiCapturePin(ULONG nPinId)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     AcquireFormatsAndModesLock();
 
     PINTYPE pinType = m_DeviceFormatsAndModes[nPinId].PinType;
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return (pinType == TelephonyBidiPin);
 }
 
 #pragma code_seg()
 BOOL CMiniportWaveRT::IsSystemRenderPin(ULONG nPinId)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     AcquireFormatsAndModesLock();
 
     PINTYPE pinType = m_DeviceFormatsAndModes[nPinId].PinType;
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return (pinType == SystemRenderPin);
 }
 
 #pragma code_seg()
 BOOL CMiniportWaveRT::IsLoopbackPin(ULONG nPinId)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     AcquireFormatsAndModesLock();
 
     PINTYPE pinType = m_DeviceFormatsAndModes[nPinId].PinType;
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return (pinType == RenderLoopbackPin);
 }
 
 #pragma code_seg()
 BOOL CMiniportWaveRT::IsOffloadPin(ULONG nPinId)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     AcquireFormatsAndModesLock();
 
     PINTYPE pinType = m_DeviceFormatsAndModes[nPinId].PinType;
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return (pinType == OffloadRenderPin);
 }
 
 #pragma code_seg()
 BOOL CMiniportWaveRT::IsBridgePin(ULONG nPinId)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     AcquireFormatsAndModesLock();
 
     PINTYPE pinType = m_DeviceFormatsAndModes[nPinId].PinType;
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return (pinType == BridgePin);
 }
 
 #pragma code_seg()
 BOOL CMiniportWaveRT::IsKeywordDetectorPin(ULONG nPinId)
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     AcquireFormatsAndModesLock();
 
     PINTYPE pinType = m_DeviceFormatsAndModes[nPinId].PinType;
 
     ReleaseFormatsAndModesLock();
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return (pinType == KeywordCapturePin);
 }
 
@@ -1262,18 +1262,18 @@ CMiniportWaveRT::StreamCreated
     PCMiniportWaveRTStream * streams        = NULL;
     ULONG                    count          = 0;
     
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     if (IsSystemCapturePin(_Pin) || IsCellularBiDiCapturePin(_Pin))
     {
         ALLOCATE_PIN_INSTANCE_RESOURCES(m_ulSystemAllocated);
-        DPF_EXIT(("[%s] [Line:(%d)]", __FUNCTION__,__LINE__));
+        DPF_EXIT();
         return STATUS_SUCCESS;
     }
     if (IsKeywordDetectorPin(_Pin))
     {
         ALLOCATE_PIN_INSTANCE_RESOURCES(m_ulKeywordDetectorAllocated);
-        DPF_EXIT(("[%s] [Line:(%d)]", __FUNCTION__,__LINE__));
+        DPF_EXIT();
         return STATUS_SUCCESS;
     }
     else if (IsLoopbackPin(_Pin))
@@ -1313,7 +1313,7 @@ CMiniportWaveRT::StreamCreated
         ASSERT(i != count);
     }
 
-    DPF_EXIT(("[%s] [Line:(%d)]", __FUNCTION__,__LINE__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -1332,18 +1332,18 @@ CMiniportWaveRT::StreamClosed
     PCMiniportWaveRTStream  * streams         = NULL;
     ULONG                     count           = 0;
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     if (IsSystemCapturePin(_Pin) || IsCellularBiDiCapturePin(_Pin))
     {
         FREE_PIN_INSTANCE_RESOURCES(m_ulSystemAllocated);
-        DPF_EXIT(("[%s] [Line:(%d)]", __FUNCTION__,__LINE__));
+        DPF_EXIT();
         return STATUS_SUCCESS;
     }
     if (IsKeywordDetectorPin(_Pin))
     {
         FREE_PIN_INSTANCE_RESOURCES(m_ulKeywordDetectorAllocated);
-        DPF_EXIT(("[%s] [Line:(%d)]", __FUNCTION__,__LINE__));
+        DPF_EXIT();
         return STATUS_SUCCESS;
     }
     else if (IsLoopbackPin(_Pin))
@@ -1392,7 +1392,7 @@ CMiniportWaveRT::StreamClosed
         UpdateDrmRights();
     }
 
-    DPF_EXIT(("[%s] [Line:(%d)]", __FUNCTION__,__LINE__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -1409,7 +1409,7 @@ CMiniportWaveRT::GetAttributesFromAttributeList
 
 Routine Description:
 
-  DPF_EXIT(("[%s]", __FUNCTION__));
+  DPF_EXIT();
   Processes attributes list and return known attributes.
 
 Arguments:
@@ -1419,7 +1419,7 @@ Arguments:
   _Size - count of bytes in the buffer pointed to by _pAttributes. The routine
     verifies sufficient buffer size while processing the attributes.
 
-  DPF_EXIT(("[%s]", __FUNCTION__));
+  DPF_EXIT();
   _pSignalProcessingMode - returns the signal processing mode extracted from
     the attribute list, or AUDIO_SIGNALPROCESSINGMODE_DEFAULT if the attribute
     is not present in the list.
@@ -1438,7 +1438,7 @@ Remarks
 {
     PAGED_CODE();
     
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     size_t cbRemaining = _Size;
 
@@ -1446,7 +1446,7 @@ Remarks
 
     if (cbRemaining < sizeof(KSMULTIPLE_ITEM))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
     cbRemaining -= sizeof(KSMULTIPLE_ITEM);
@@ -1460,7 +1460,7 @@ Remarks
     {
         if (cbRemaining < sizeof(KSATTRIBUTE))
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_PARAMETER;
         }
 
@@ -1470,13 +1470,13 @@ Remarks
 
             if (cbRemaining < sizeof(KSATTRIBUTE_AUDIOSIGNALPROCESSING_MODE))
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INVALID_PARAMETER;
             }
 
             if (attributeHeader->Size != sizeof(KSATTRIBUTE_AUDIOSIGNALPROCESSING_MODE))
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_INVALID_PARAMETER;
             }
 
@@ -1487,7 +1487,7 @@ Remarks
         }
         else
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_NOT_SUPPORTED;
         }
 
@@ -1498,7 +1498,7 @@ Remarks
         cbRemaining -= cbAttribute;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -1514,7 +1514,7 @@ CMiniportWaveRT::IsFormatSupported
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                            ntStatus = STATUS_NO_MATCH;
     PKSDATAFORMAT_WAVEFORMATEXTENSIBLE  pPinFormats = NULL;
@@ -1524,7 +1524,7 @@ CMiniportWaveRT::IsFormatSupported
 
     if (_ulPin >= m_pMiniportPair->WaveDescriptor->PinCount)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -1569,7 +1569,7 @@ CMiniportWaveRT::IsFormatSupported
         break;
     }
     DPF(D_TERSE, ("result: (0x%08x\n)", ntStatus));
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -1582,13 +1582,13 @@ CMiniportWaveRT::EvtFormatChangeHandler
     _In_opt_    PVOID   Context
 )
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PCMiniportWaveRT This = PCMiniportWaveRT(Context);
     if (This == NULL)
     {
         DPF(D_ERROR, ("EvtFormatChangeHandler: context is null")); 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
 
@@ -1656,14 +1656,14 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
 
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     // All properties handled by this handler require at least a KSP_PIN descriptor.
 
     // Verify instance data stores at least KSP_PIN fields beyond KSPPROPERTY.
     if (PropertyRequest->InstanceSize < (sizeof(KSP_PIN) - RTL_SIZEOF_THROUGH_FIELD(KSP_PIN, Property)))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -1693,7 +1693,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
 
     if (!NT_SUCCESS(ntStatus))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return ntStatus;
     }
 
@@ -1704,7 +1704,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
     {
         ULONG flags = PropertyRequest->PropertyItem->Flags;
         
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return PropertyHandler_BasicSupport(PropertyRequest, flags, VT_ILLEGAL);
     }
 
@@ -1712,12 +1712,12 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
     if (PropertyRequest->ValueSize == 0)
     {
         PropertyRequest->ValueSize = cbMinSize;
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_BUFFER_OVERFLOW;
     }
     if (PropertyRequest->ValueSize < cbMinSize)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_BUFFER_TOO_SMALL;
     }
 
@@ -1725,7 +1725,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
     // Only SET is supported for this property
     if ((PropertyRequest->Verb & KSPROPERTY_TYPE_SET) == 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_DEVICE_REQUEST;
     }
 #endif
@@ -1789,7 +1789,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
 
                 if (!bFound)
                 {
-                    DPF_EXIT(("[%s]", __FUNCTION__));
+                    DPF_EXIT();
                     return STATUS_NOT_SUPPORTED;
                 }
 
@@ -1809,7 +1809,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
             numModes = GetPinSupportedDeviceModes(kspPin->PinId, &modeInfo);
             if (numModes == 0 || modeInfo->DefaultFormat == NULL)
             {
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_NOT_SUPPORTED;
             }
 
@@ -1827,7 +1827,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
             pKsFormat);
         if (!NT_SUCCESS(ntStatus))
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return ntStatus;
         }
 
@@ -1841,7 +1841,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerProposedFormat
 
@@ -1880,7 +1880,7 @@ Arguments:
 
 --*/
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(m_pPortEvents != NULL);
 
@@ -1905,7 +1905,7 @@ CMiniportWaveRT::SendPNPNotification(
     NTSTATUS                status = STATUS_SUCCESS;
     PPCNOTIFICATION_BUFFER  buffer = NULL;
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // Allocate a notification buffer.
     status = m_pPortClsNotifications->AllocNotificationBuffer(PagedPool,
@@ -1944,7 +1944,7 @@ CMiniportWaveRT::PropertyHandlerAudioEffectsDiscoveryEffectsList
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PKSP_PIN                kspPin                  = NULL;
     NTSTATUS                ntStatus                = STATUS_INVALID_PARAMETER;
@@ -1954,7 +1954,7 @@ CMiniportWaveRT::PropertyHandlerAudioEffectsDiscoveryEffectsList
     // Verify instance data stores at least KSP_PIN fields beyond KSPPROPERTY.
     if (PropertyRequest->InstanceSize < (sizeof(KSP_PIN) - RTL_SIZEOF_THROUGH_FIELD(KSP_PIN, Property)))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -2034,7 +2034,7 @@ CMiniportWaveRT::PropertyHandlerAudioEffectsDiscoveryEffectsList
 
 Done:
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerAudioEffectsDiscoveryEffectsList
 
@@ -2052,9 +2052,9 @@ CMiniportWaveRT::PropertyHandlerModulesListRequest
 
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return AudioModule_GenericHandler_ModulesListRequest(
                 PropertyRequest,
                 GetAudioModuleList(),
@@ -2071,9 +2071,9 @@ CMiniportWaveRT::PropertyHandlerModuleCommand
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return AudioModule_GenericHandler_ModuleCommand(
                 PropertyRequest,
                 GetAudioModuleList(),
@@ -2090,9 +2090,9 @@ CMiniportWaveRT::PropertyHandlerModuleNotificationDeviceId
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return AudioModule_GenericHandler_ModuleNotificationDeviceId(
                 PropertyRequest,
                 GetAudioModuleNotificationDeviceId());
@@ -2186,14 +2186,14 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
 
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     // All properties handled by this handler require at least a KSP_PIN descriptor.
 
     // Verify instance data stores at least KSP_PIN fields beyond KSPPROPERTY.
     if (PropertyRequest->InstanceSize < (sizeof(KSP_PIN) - RTL_SIZEOF_THROUGH_FIELD(KSP_PIN, Property)))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -2202,7 +2202,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
 
     if (kspPin->PinId >= m_pMiniportPair->WaveDescriptor->PinCount)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -2215,7 +2215,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
 
     if (modeInfo == NULL)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
 
@@ -2234,7 +2234,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
 
     if (!bFound)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
 
@@ -2243,7 +2243,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
     //
     if (PropertyRequest->Verb & KSPROPERTY_TYPE_BASICSUPPORT)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return PropertyHandler_BasicSupport(PropertyRequest, PropertyRequest->PropertyItem->Flags, VT_ILLEGAL);
     }
 
@@ -2256,7 +2256,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
     ntStatus = GetAttributesFromAttributeList(pKsItemsHeader, cbItemsList, &signalProcessingMode);
     if (!NT_SUCCESS(ntStatus))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return ntStatus;
     }
 
@@ -2277,7 +2277,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
     // proprosed format for this specific mode.
     if (!bFound || modeInfo->DefaultFormat == NULL)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
 
@@ -2291,7 +2291,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
 
     if (cbItemsList > MAXULONG)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -2299,14 +2299,14 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
     ntStatus = RtlULongAdd(cbMinSize, (ULONG)cbItemsList, &cbMinSize);
     if (!NT_SUCCESS(ntStatus))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
         
     // Property not supported.
     if (cbMinSize == 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
 
@@ -2314,19 +2314,19 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
     if (PropertyRequest->ValueSize == 0)
     {
         PropertyRequest->ValueSize = cbMinSize;
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_BUFFER_OVERFLOW;
     }
     if (PropertyRequest->ValueSize < cbMinSize)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_BUFFER_TOO_SMALL;
     }
 
     // Only GET is supported for this property
     if ((PropertyRequest->Verb & KSPROPERTY_TYPE_GET) == 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_DEVICE_REQUEST;
     }
 
@@ -2340,7 +2340,7 @@ CMiniportWaveRT::PropertyHandlerProposedFormat2
     
     PropertyRequest->ValueSize = cbMinSize;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 } // PropertyHandlerProposedFormat
 
@@ -2360,24 +2360,24 @@ CMiniportWaveRT::PropertyHandlerEffectListRequest
 
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // This specific APO->driver communication example is mainly added to show to this communication is done.
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     // It skips the pin id validation and returns pin specific answers to the caller, which a real miniport 
     // audio driver probably needs to take care of.
 
     // Handle KSPROPERTY_TYPE_BASICSUPPORT query
     if (PropertyRequest->Verb & KSPROPERTY_TYPE_BASICSUPPORT)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return PropertyHandler_BasicSupport(PropertyRequest, PropertyRequest->PropertyItem->Flags, VT_ILLEGAL);
     }
 
     // Verify instance data stores at least KSP_PIN fields beyond KSPPROPERTY.
     if (PropertyRequest->InstanceSize < (sizeof(KSP_PIN) - RTL_SIZEOF_THROUGH_FIELD(KSP_PIN, Property)))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -2395,12 +2395,12 @@ CMiniportWaveRT::PropertyHandlerEffectListRequest
         if (PropertyRequest->ValueSize == 0)
         {
             PropertyRequest->ValueSize = cbMinSize;
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_BUFFER_OVERFLOW;
         }
         if (PropertyRequest->ValueSize < cbMinSize)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_BUFFER_TOO_SMALL;
         }
         // Value is a KSMULTIPLE_ITEM followed by list of GUIDs.
@@ -2415,11 +2415,11 @@ CMiniportWaveRT::PropertyHandlerEffectListRequest
         ksMultipleItem->Count = ulEffectsCount;
 
         PropertyRequest->ValueSize = ksMultipleItem->Size;
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_SUCCESS;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_INVALID_DEVICE_REQUEST;
 
 } // PropertyHandlerEffectListRequest
@@ -2450,7 +2450,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     NTSTATUS        ntStatus                = STATUS_UNSUCCESSFUL;
     ULONG           ulMixDrmContentId       = 0;
@@ -2464,14 +2464,14 @@ Return Value:
     //
     if (!m_pDrmPort)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_UNSUCCESSFUL;
     }
 
     ulContentIds = new (POOL_FLAG_NON_PAGED, MINWAVERT_POOLTAG) ULONG[m_ulMaxSystemStreams + m_ulMaxOffloadStreams];
     if (!ulContentIds)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
@@ -2563,7 +2563,7 @@ Return Value:
     delete [] ulContentIds;
     ulContentIds = NULL;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // UpdateDrmRights
 

--- a/sysvad/EndpointsCommon/minwavertstream.cpp
+++ b/sysvad/EndpointsCommon/minwavertstream.cpp
@@ -111,8 +111,8 @@ Return Value:
     ASSERT(m_SidebandStarted == FALSE);
 #endif  // SYSVAD_BTH_BYPASS
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
-DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_ENTER();
+DPF_EXIT();
 } // ~CMiniportWaveRTStream
 
 //=============================================================================
@@ -538,7 +538,7 @@ NTSTATUS CMiniportWaveRTStream::AllocateBufferWithNotification
 )
 {
     NTSTATUS ntStatus = STATUS_SUCCESS;
-	DPF_ENTER(("[%s]", __FUNCTION__));
+	DPF_ENTER();
     PAGED_CODE();
 
     ULONG ulBufferDurationMs = 0;
@@ -608,7 +608,7 @@ NTSTATUS CMiniportWaveRTStream::AllocateBufferWithNotification
 
 Done:
     DPF(D_TERSE,("ntStatus:(0x%08x)\n", ntStatus));
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -638,7 +638,7 @@ VOID CMiniportWaveRTStream::FreeBufferWithNotification
     m_ulDmaBufferSize = 0;
     m_ulNotificationsPerBuffer = 0;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return;
 }
 
@@ -659,7 +659,7 @@ NTSTATUS CMiniportWaveRTStream::RegisterNotificationEvent
         MINWAVERTSTREAM_POOLTAG);
     if (NULL == nleNew)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
@@ -675,7 +675,7 @@ NTSTATUS CMiniportWaveRTStream::RegisterNotificationEvent
             if (nleCurrent->NotificationEvent == NotificationEvent_)
             {
                 ExFreePoolWithTag( nleNew, MINWAVERTSTREAM_POOLTAG );
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_UNSUCCESSFUL;
             }
 
@@ -685,7 +685,7 @@ NTSTATUS CMiniportWaveRTStream::RegisterNotificationEvent
 
     InsertTailList(&m_NotificationList, &(nleNew->ListEntry));
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -710,7 +710,7 @@ NTSTATUS CMiniportWaveRTStream::UnregisterNotificationEvent
             {
                 RemoveEntryList( leCurrent );
                 ExFreePoolWithTag( nleCurrent, MINWAVERTSTREAM_POOLTAG );
-                DPF_EXIT(("[%s]", __FUNCTION__));
+                DPF_EXIT();
                 return STATUS_SUCCESS;
             }
 
@@ -718,7 +718,7 @@ NTSTATUS CMiniportWaveRTStream::UnregisterNotificationEvent
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_NOT_FOUND;
 }
 
@@ -734,7 +734,7 @@ NTSTATUS CMiniportWaveRTStream::GetClockRegister
 
     PAGED_CODE();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_NOT_IMPLEMENTED;
 }
 
@@ -749,7 +749,7 @@ NTSTATUS CMiniportWaveRTStream::GetPositionRegister
 
     PAGED_CODE();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_NOT_IMPLEMENTED;
 }
 
@@ -811,7 +811,7 @@ _Out_   MEMORY_CACHING_TYPE    *CacheType_
 
     if ((0 == RequestedSize_) || (RequestedSize_ < m_pWfExt->Format.nBlockAlign))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_UNSUCCESSFUL;
     }
 
@@ -825,7 +825,7 @@ _Out_   MEMORY_CACHING_TYPE    *CacheType_
 
     if (NULL == pBufferMdl)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_UNSUCCESSFUL;
     }
 
@@ -854,7 +854,7 @@ _Out_   MEMORY_CACHING_TYPE    *CacheType_
     *OffsetFromFirstPage_ = 0;
     *CacheType_ = MmCached;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -878,7 +878,7 @@ NTSTATUS CMiniportWaveRTStream::GetPosition
     // Return failure if this is the keyword detector pin
     if (m_pMiniport->IsKeywordDetectorPin(m_ulPin))
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
 
@@ -904,7 +904,7 @@ NTSTATUS CMiniportWaveRTStream::GetPosition
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
 Done:
 #endif // defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -941,7 +941,7 @@ NTSTATUS CMiniportWaveRTStream::GetReadPacket
     // The call must be from event driven mode
     if(m_ulNotificationsPerBuffer == 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
     
@@ -949,7 +949,7 @@ NTSTATUS CMiniportWaveRTStream::GetReadPacket
 
     if (m_KsState < KSSTATE_PAUSE)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_DEVICE_STATE;
     }
 
@@ -962,7 +962,7 @@ NTSTATUS CMiniportWaveRTStream::GetReadPacket
         {
             m_ulLastOsReadPacket = *PacketNumber;
         }
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return ntStatus;
     }
 
@@ -983,7 +983,7 @@ NTSTATUS CMiniportWaveRTStream::GetReadPacket
     // If no new packets are available...
     if (availablePacketNumber == m_ulLastOsReadPacket)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_DEVICE_NOT_READY;
     }
 
@@ -998,7 +998,7 @@ NTSTATUS CMiniportWaveRTStream::GetReadPacket
     // Return next packet number to be read
     *PacketNumber = availablePacketNumber;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     // Compute and return timestamp corresponding to the end of the available packet. In a real hardware
     // driver, the timestamp would be computed in a driver and hardware specific manner. In this sample
     // driver, it is extrapolated from the sample driver's internal simulated position correlation
@@ -1024,7 +1024,7 @@ NTSTATUS CMiniportWaveRTStream::GetReadPacket
     // Update the last packet read by the OS
     m_ulLastOsReadPacket = availablePacketNumber;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -1042,7 +1042,7 @@ NTSTATUS CMiniportWaveRTStream::SetWritePacket
     // The call must be from event driven mode
     if (m_ulNotificationsPerBuffer == 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
 
@@ -1051,7 +1051,7 @@ NTSTATUS CMiniportWaveRTStream::SetWritePacket
     // This function should not be called once EoS has been set.
     if (m_bEoSReceived)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_INVALID_DEVICE_STATE;
     }
 
@@ -1074,12 +1074,12 @@ NTSTATUS CMiniportWaveRTStream::SetWritePacket
     LONG deltaFromExpectedPacket = PacketNumber - expectedPacket;   // Modulo arithemetic
     if (deltaFromExpectedPacket < 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_DATA_LATE_ERROR;
     }
     else if (deltaFromExpectedPacket > 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_DATA_OVERRUN;
     }
 
@@ -1092,7 +1092,7 @@ NTSTATUS CMiniportWaveRTStream::SetWritePacket
     {
         if (EosPacketLength > packetSize)
         {
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             return STATUS_INVALID_PARAMETER;
         }
         else {
@@ -1109,7 +1109,7 @@ NTSTATUS CMiniportWaveRTStream::SetWritePacket
 
         // This function sets the current write position to the specified byte in the DMA buffer.
         // Will check if the write position is smaller than the DMA buffer size.
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // Will not return an error when the passed in parameter is 0.
         // Will also check if this function was called with the same write position(in event mode only)
         // Underruning will also be checked via timer mechanism
@@ -1123,7 +1123,7 @@ NTSTATUS CMiniportWaveRTStream::SetWritePacket
         m_ulLastOsWritePacket = oldLastOsWritePacket;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -1140,11 +1140,11 @@ NTSTATUS CMiniportWaveRTStream::GetOutputStreamPresentationPosition
     // The call must be from event driven mode
     if(m_ulNotificationsPerBuffer == 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return GetPresentationPosition(pPresentationPosition);
 }
 
@@ -1161,7 +1161,7 @@ NTSTATUS CMiniportWaveRTStream::GetPacketCount
     // The call must be from event driven mode
     if(m_ulNotificationsPerBuffer == 0)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return STATUS_NOT_SUPPORTED;
     }
     
@@ -1178,7 +1178,7 @@ NTSTATUS CMiniportWaveRTStream::GetPacketCount
     *pPacketCount = LODWORD(m_llPacketCounter);
     KeReleaseSpinLock(&m_PositionSpinLock, oldIrql);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return STATUS_SUCCESS;
 }
 
@@ -1189,7 +1189,7 @@ NTSTATUS CMiniportWaveRTStream::SetState
     _In_    KSSTATE State_
 )
 {
-	DPF_ENTER(("[%s]", __FUNCTION__));
+	DPF_ENTER();
     NTSTATUS        ntStatus        = STATUS_SUCCESS;
     PADAPTERCOMMON  pAdapterComm    = m_pMiniport->GetAdapterCommObj();
     KIRQL oldIrql;
@@ -1408,7 +1408,7 @@ NTSTATUS CMiniportWaveRTStream::SetState
 #if defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
 Done:
 #endif  // defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -1428,7 +1428,7 @@ NTSTATUS CMiniportWaveRTStream::SetFormat
         ntStatus = m_SaveData.SetDataFormat(DataFormat_);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -1441,7 +1441,7 @@ VOID CMiniportWaveRTStream::UpdatePosition
     _In_ LARGE_INTEGER ilQPC
 )
 {
-	DPF_ENTER(("[%s]", __FUNCTION__));
+	DPF_ENTER();
 
     // Convert ticks to 100ns units.
     LONGLONG  hnsCurrentTime = KSCONVERT_PERFORMANCE_TIME(m_ullPerformanceCounterFrequency.QuadPart, ilQPC);
@@ -1629,7 +1629,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS    ntStatus;
     ULONG       ulOldContentId = contentId;
@@ -1688,7 +1688,7 @@ Return Value:
     // For more information, see MSDN's DRM Functions and Interfaces.
     //
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // SetContentId
 
@@ -1710,7 +1710,7 @@ Return Value:
 
 --*/
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS  ntStatus  = STATUS_INVALID_DEVICE_STATE;
         
@@ -1728,7 +1728,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;        
 }
 #endif // defined(SYSVAD_BTH_BYPASS) || defined(SYSVAD_USB_SIDEBAND)
@@ -1748,9 +1748,9 @@ CMiniportWaveRTStream::PropertyHandlerModulesListRequest
 
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return AudioModule_GenericHandler_ModulesListRequest(
                 PropertyRequest,
                 GetAudioModuleList(),
@@ -1767,9 +1767,9 @@ CMiniportWaveRTStream::PropertyHandlerModuleCommand
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return AudioModule_GenericHandler_ModuleCommand(
                 PropertyRequest,
                 GetAudioModuleList(),

--- a/sysvad/EndpointsCommon/speakerhptopo.cpp
+++ b/sysvad/EndpointsCommon/speakerhptopo.cpp
@@ -49,7 +49,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG                   nPinId = (ULONG)-1;
@@ -104,7 +104,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -134,7 +134,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG                   nPinId = (ULONG)-1;
@@ -197,7 +197,7 @@ Return Value:
                         // a client application can call IKsJackDescription2::GetJackDescription2 to read 
                         // the JackCapabilities flag of the KSJACK_DESCRIPTION2 structure. If this flag has
                         // the JACKDESC2_PRESENCE_DETECT_CAPABILITY bit set, it indicates that the endpoint 
-                        DPF_EXIT(("[%s]", __FUNCTION__));
+                        DPF_EXIT();
                         // does in fact support jack presence detection. In that case, the return value of 
                         // the IsConnected member can be interpreted to accurately reflect the insertion status
                         // of the jack."
@@ -215,7 +215,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -246,7 +246,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // PropertyRequest structure is filled by portcls. 
     // MajorTarget is a pointer to miniport object for miniports.
@@ -273,7 +273,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandler_SpeakerHpTopoFilter
 

--- a/sysvad/EndpointsCommon/speakertopo.cpp
+++ b/sysvad/EndpointsCommon/speakertopo.cpp
@@ -48,7 +48,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // PropertyRequest structure is filled by portcls. 
     // MajorTarget is a pointer to miniport object for miniports.
@@ -104,7 +104,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandler_SpeakerTopoFilter
 

--- a/sysvad/TabletAudioSample/micintopo.cpp
+++ b/sysvad/TabletAudioSample/micintopo.cpp
@@ -49,7 +49,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG                   nPinId = (ULONG)-1;
@@ -104,7 +104,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -134,7 +134,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG                   nPinId = (ULONG)-1;
@@ -197,7 +197,7 @@ Return Value:
                         // a client application can call IKsJackDescription2::GetJackDescription2 to read 
                         // the JackCapabilities flag of the KSJACK_DESCRIPTION2 structure. If this flag has
                         // the JACKDESC2_PRESENCE_DETECT_CAPABILITY bit set, it indicates that the endpoint 
-                        DPF_EXIT(("[%s]", __FUNCTION__));
+                        DPF_EXIT();
                         // does in fact support jack presence detection. In that case, the return value of 
                         // the IsConnected member can be interpreted to accurately reflect the insertion status
                         // of the jack."
@@ -215,7 +215,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -245,7 +245,7 @@ Return Value:
 
     ASSERT(PropertyRequest);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // PropertryRequest structure is filled by portcls. 
     // MajorTarget is a pointer to miniport object for miniports.
@@ -264,7 +264,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandler_MicInTopoFilter
 

--- a/sysvad/adapter.cpp
+++ b/sysvad/adapter.cpp
@@ -1067,7 +1067,7 @@ Return Value:
     PUNKNOWN                    pUnknownCommon  = NULL;
     PortClassDeviceContext*     pExtension      = static_cast<PortClassDeviceContext*>(DeviceObject->DeviceExtension);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
     // create a new adapter common object
@@ -1158,7 +1158,7 @@ Exit:
     //
     SAFE_RELEASE(pUnknownCommon);
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // StartDevice
 

--- a/sysvad/basetopo.cpp
+++ b/sysvad/basetopo.cpp
@@ -46,7 +46,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     m_AdapterCommon     = NULL;
 
@@ -56,7 +56,7 @@ Return Value:
     
     ASSERT(DeviceMaxChannels > 0);
     m_DeviceMaxChannels = DeviceMaxChannels;
-DPF_EXIT(("[%s]",__FUNCTION__));
+DPF_EXIT();
 } // CMiniportTopologySYSVAD
 
 CMiniportTopologySYSVAD::~CMiniportTopologySYSVAD
@@ -79,11 +79,11 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     SAFE_RELEASE(m_AdapterCommon);
     SAFE_RELEASE(m_PortEvents);
-DPF_EXIT(("[%s]",__FUNCTION__));
+DPF_EXIT();
 } // ~CMiniportTopologySYSVAD
 
 //=============================================================================
@@ -141,9 +141,9 @@ Return Value:
 
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
-    DPF_EXIT(("[%s]",__FUNCTION__));
+    DPF_EXIT();
     return (STATUS_NOT_IMPLEMENTED);
 } // DataRangeIntersection
 
@@ -177,11 +177,11 @@ Return Value:
 
     ASSERT(OutFilterDescriptor);
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     *OutFilterDescriptor = m_FilterDescriptor;
 
-    DPF_EXIT(("[%s]",__FUNCTION__));
+    DPF_EXIT();
     return (STATUS_SUCCESS);
 } // GetDescription
 
@@ -216,7 +216,7 @@ Return Value:
     ASSERT(UnknownAdapter_);
     ASSERT(Port_);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS    ntStatus;
 
@@ -247,7 +247,7 @@ Return Value:
         SAFE_RELEASE(m_PortEvents);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // Init
 
@@ -345,7 +345,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                    ntStatus = STATUS_INVALID_DEVICE_REQUEST;
 
@@ -388,7 +388,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]",__FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerMuxSource
 
@@ -417,7 +417,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus=STATUS_SUCCESS;
 
@@ -457,7 +457,7 @@ Return Value:
                 } 
                 else if (PropertyRequest->ValueSize >= sizeof(KSPROPERTY_DESCRIPTION))
                 {
-                    DPF_EXIT(("[%s]",__FUNCTION__));
+                    DPF_EXIT();
                     // if return buffer can hold a KSPROPERTY_DESCRIPTION, return it
                     //
                     PKSPROPERTY_DESCRIPTION PropDesc = PKSPROPERTY_DESCRIPTION(PropertyRequest->Value);
@@ -472,7 +472,7 @@ Return Value:
 
                     if ( PropertyRequest->ValueSize >= ExpectedSize )
                     {
-                        DPF_EXIT(("[%s]",__FUNCTION__));
+                        DPF_EXIT();
                         // Extra information to return
                         PropDesc->MembersListCount  = 1;
 
@@ -494,13 +494,13 @@ Return Value:
                             PeakMeterBounds->UnsignedMaximum = 0xffffffff;
                         }
 
-                        DPF_EXIT(("[%s]",__FUNCTION__));
+                        DPF_EXIT();
                         // set the return value size
                         PropertyRequest->ValueSize = ExpectedSize;
                     }
                     else
                     {
-                        DPF_EXIT(("[%s]",__FUNCTION__));
+                        DPF_EXIT();
                         // No extra information to return.
                         PropertyRequest->ValueSize = sizeof(KSPROPERTY_DESCRIPTION);
                     }
@@ -509,7 +509,7 @@ Return Value:
                 } 
                 else if (PropertyRequest->ValueSize >= sizeof(ULONG))
                 {
-                    DPF_EXIT(("[%s]",__FUNCTION__));
+                    DPF_EXIT();
                     // if return buffer can hold a ULONG, return the access flags
                     //
                     *(PULONG(PropertyRequest->Value)) = KSPROPERTY_TYPE_ALL;
@@ -620,7 +620,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]",__FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerDevSpecific
 
@@ -644,7 +644,7 @@ Arguments:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(m_PortEvents != NULL);
 
@@ -686,7 +686,7 @@ Arguments:
 
 --*/
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(m_PortEvents != NULL);
 

--- a/sysvad/common.cpp
+++ b/sysvad/common.cpp
@@ -638,7 +638,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     if (m_pHW)
     {
@@ -659,7 +659,7 @@ Return Value:
 #ifdef SYSVAD_USB_SIDEBAND
     ASSERT(IsListEmpty(&m_PowerRelations));
 #endif // SYSVAD_USB_SIDEBAND
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 } // ~CAdapterCommon  
 
 //=============================================================================
@@ -766,7 +766,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(DeviceObject);
 
@@ -845,7 +845,7 @@ Return Value:
     CSaveData::SetDeviceObject(DeviceObject);   //device object is needed by CSaveData
 Done:
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // Init
 
@@ -1056,7 +1056,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     SAFE_RELEASE(m_pServiceGroupWave);
 
@@ -1066,7 +1066,7 @@ Return Value:
     {
         m_pServiceGroupWave->AddRef();
     }
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 } // SetWaveServiceGroup
 
 //=============================================================================
@@ -1519,7 +1519,7 @@ Note:
   
 --*/
 {
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // Notify all registered miniports of a power state change
     PLIST_ENTRY le = NULL;
@@ -1562,7 +1562,7 @@ Note:
         }
     }
 	DPF(D_TERSE,("Entering %x", NewState.DeviceState));
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 } // PowerStateChange
 
 //=============================================================================
@@ -1592,9 +1592,9 @@ Return Value:
 {
     UNREFERENCED_PARAMETER(PowerDeviceCaps);
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return (STATUS_SUCCESS);
 } // QueryDeviceCapabilities
 
@@ -1623,7 +1623,7 @@ Return Value:
 {
     NTSTATUS status = STATUS_SUCCESS;
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // query each miniport for it's power state, we're finished if even one indicates
     // it cannot go to this power state.
@@ -1638,7 +1638,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 } // QueryPowerChangeState
 
@@ -1662,7 +1662,7 @@ Create the audio interface (in disabled mode).
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS        ntStatus;
     UNICODE_STRING  referenceString;
@@ -1723,7 +1723,7 @@ Done:
         RtlFreeUnicodeString(AudioSymbolicLinkName);
         RtlZeroMemory(AudioSymbolicLinkName, sizeof(UNICODE_STRING));
     }
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -1793,7 +1793,7 @@ Return Value:
 
 --*/
     PAGED_CODE();
-    DPF_ENTER(("[%s %S]", __FUNCTION__, Name));
+    DPF_ENTER();
 
     ASSERT(Name != NULL);
     ASSERT(m_pDeviceObject != NULL);
@@ -1927,7 +1927,7 @@ Return Value:
         miniport->Release();
     }
 
-    DPF_EXIT(("[%s %S]", __FUNCTION__, Name));
+    DPF_EXIT();
     return ntStatus;
 } // InstallSubDevice
 
@@ -1955,7 +1955,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(m_pDeviceObject != NULL);
     
@@ -1964,7 +1964,7 @@ Return Value:
     
     if (NULL == UnknownPort)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return ntStatus;
     }
 
@@ -1990,7 +1990,7 @@ Return Value:
         unregisterSubdevice->Release();
     }
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -2019,7 +2019,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     ASSERT(m_pDeviceObject != NULL);
     
@@ -2078,7 +2078,7 @@ Return Value:
         DisconnectTopologies(UnknownTopology, UnknownWave, PhysicalConnections, PhysicalConnectionCount);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -2107,7 +2107,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     ASSERT(m_pDeviceObject != NULL);
     
@@ -2159,7 +2159,7 @@ Return Value:
                     break;
             }
 
-            DPF_EXIT(("[%s]", __FUNCTION__));
+            DPF_EXIT();
             // cache and return the first error encountered, as it's likely the most relevent
             if (NT_SUCCESS(ntStatus))
             {
@@ -2173,7 +2173,7 @@ Return Value:
     //
     SAFE_RELEASE(unregisterPhysicalConnection);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -2188,9 +2188,9 @@ CAdapterCommon::GetCachedSubdevice
 )
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     // search list, return interface to device if found, fail if not found
     PLIST_ENTRY le = NULL;
     BOOL bFound = FALSE;
@@ -2217,7 +2217,7 @@ CAdapterCommon::GetCachedSubdevice
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return bFound?STATUS_SUCCESS:STATUS_OBJECT_NAME_NOT_FOUND;
 }
 
@@ -2234,7 +2234,7 @@ CAdapterCommon::CacheSubdevice
 )
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // add the item with this name/interface to the list
     NTSTATUS         ntStatus       = STATUS_SUCCESS;
@@ -2280,7 +2280,7 @@ CAdapterCommon::CacheSubdevice
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -2293,7 +2293,7 @@ CAdapterCommon::RemoveCachedSubdevice
 )
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // search list, remove the entry from the list
 
@@ -2318,7 +2318,7 @@ CAdapterCommon::RemoveCachedSubdevice
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return bRemoved?STATUS_SUCCESS:STATUS_OBJECT_NAME_NOT_FOUND;
 }
 
@@ -2327,7 +2327,7 @@ VOID
 CAdapterCommon::EmptySubdeviceCache()
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     while (!IsListEmpty(&m_SubdeviceCache))
     {
@@ -2349,7 +2349,7 @@ VOID
 CAdapterCommon::Cleanup()
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
 #ifdef SYSVAD_BTH_BYPASS
     //
@@ -2466,7 +2466,7 @@ CAdapterCommon::UpdatePowerRelations(_In_ PIRP Irp)
 #pragma prefast(suppress: __WARNING_BUFFER_OVERFLOW, "the access to newRelation->Objects is in-range")
         newRelations->Objects[newRelations->Count] = powerDepDo->Pdo;
 
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         // Add a reference on the PDO before returning it as a dependency.
         // PnP will remove the reference when appropriate as per msdn.
         // https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/irp-mn-query-device-relations#operation
@@ -2509,7 +2509,7 @@ Exit:
     Irp->IoStatus.Status = status;
     Irp->IoStatus.Information = (ULONG_PTR)newRelations;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 #endif // SYSVAD_USB_SIDEBAND
@@ -2529,7 +2529,7 @@ CAdapterCommon::InstallEndpointFilters
 )
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     NTSTATUS            ntStatus            = STATUS_SUCCESS;
     PUNKNOWN            unknownTopology     = NULL;
@@ -2682,7 +2682,7 @@ CAdapterCommon::InstallEndpointFilters
     SAFE_RELEASE(unknownMiniWave);
     SAFE_RELEASE(unknownWave);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -2697,7 +2697,7 @@ CAdapterCommon::RemoveEndpointFilters
 )
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     NTSTATUS    ntStatus   = STATUS_SUCCESS;
     
@@ -2737,7 +2737,7 @@ CAdapterCommon::RemoveEndpointFilters
     //
     ntStatus = STATUS_SUCCESS;
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -2754,7 +2754,7 @@ CAdapterCommon::GetFilters
 )
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     NTSTATUS    ntStatus   = STATUS_SUCCESS; 
     PUNKNOWN            unknownTopologyPort     = NULL;
@@ -2762,7 +2762,7 @@ CAdapterCommon::GetFilters
     PUNKNOWN            unknownWavePort         = NULL;
     PUNKNOWN            unknownWaveMiniport     = NULL;
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     // if the client requested the topology filter, find it and return it
     if (UnknownTopologyPort != NULL || UnknownTopologyMiniport != NULL)
     {
@@ -2781,7 +2781,7 @@ CAdapterCommon::GetFilters
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     // if the client requested the wave filter, find it and return it
     if (NT_SUCCESS(ntStatus) && (UnknownWavePort != NULL || UnknownWaveMiniport != NULL))
     {
@@ -2800,7 +2800,7 @@ CAdapterCommon::GetFilters
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -2814,7 +2814,7 @@ CAdapterCommon::SetIdlePowerManagement
 )
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS      ntStatus   = STATUS_SUCCESS; 
     IUnknown      *pUnknown = NULL;
@@ -2861,7 +2861,7 @@ CAdapterCommon::SetIdlePowerManagement
     SAFE_RELEASE(pUnknown);
     SAFE_RELEASE(pPortClsPower);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -2890,13 +2890,13 @@ Arguments:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     CAdapterCommon        * This;
     
     if (WorkItem == NULL) 
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
 
@@ -2983,7 +2983,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     PLIST_ENTRY     le          = NULL;
     BthHfpDevice  * bthDevice   = NULL;
@@ -3010,7 +3010,7 @@ Return Value:
     
     ExReleaseFastMutex(&m_BthHfpFastMutex);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return bthDevice;
 }
 
@@ -3038,7 +3038,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS            ntStatus        = STATUS_SUCCESS;
     BthHfpDevice      * bthDevice       = NULL;
@@ -3134,7 +3134,7 @@ Done:
         }
     }
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -3162,7 +3162,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS            ntStatus        = STATUS_SUCCESS;
     BthHfpDevice      * bthDevice       = NULL;
@@ -3235,7 +3235,7 @@ Done:
         SAFE_RELEASE(bthDevice);
     }
     
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -3263,7 +3263,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
     
     NTSTATUS                              ntStatus      = STATUS_SUCCESS;
     CAdapterCommon                      * This          = NULL;
@@ -3308,7 +3308,7 @@ Return Value:
     }
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -3329,7 +3329,7 @@ Return Value:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                ntStatus = STATUS_SUCCESS;
     WDF_WORKITEM_CONFIG     wiConfig;
@@ -3401,7 +3401,7 @@ Return Value:
     ntStatus = STATUS_SUCCESS;
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -3418,14 +3418,14 @@ Routine Description:
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
     // Do nothing if Bluetooth HFP environment was not correctly initialized.
     //
     if (m_BthHfpEnableCleanup == FALSE)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
     
@@ -3505,13 +3505,13 @@ WorkItem    - WDF work-item object.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     CAdapterCommon        * This;
 
     if (WorkItem == NULL)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
 
@@ -3598,7 +3598,7 @@ UsbSidebandDevice pointer or NULL.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PLIST_ENTRY     le = NULL;
     UsbHsDevice  * usbDevice = NULL;
@@ -3625,7 +3625,7 @@ UsbSidebandDevice pointer or NULL.
 
     ExReleaseFastMutex(&m_UsbSidebandFastMutex);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return usbDevice;
 }
 
@@ -3653,7 +3653,7 @@ NT status code.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS            ntStatus = STATUS_SUCCESS;
     UsbHsDevice         *usbHsDevice = NULL;
@@ -3749,7 +3749,7 @@ Done:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -3777,7 +3777,7 @@ NT status code.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS            ntStatus = STATUS_SUCCESS;
     UsbHsDevice         *usbHsDevice = NULL;
@@ -3850,7 +3850,7 @@ Done:
         SAFE_RELEASE(usbHsDevice);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -3878,7 +3878,7 @@ NT status code.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                              ntStatus = STATUS_SUCCESS;
     CAdapterCommon                      * This = NULL;
@@ -3923,7 +3923,7 @@ NT status code.
     }
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -3944,7 +3944,7 @@ NT status code.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                ntStatus = STATUS_SUCCESS;
     WDF_WORKITEM_CONFIG     wiConfig;
@@ -4016,7 +4016,7 @@ NT status code.
     ntStatus = STATUS_SUCCESS;
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -4053,7 +4053,7 @@ CAdapterCommon::AddDeviceAsPowerDependency
     IoInvalidateDeviceRelations(m_pPhysicalDeviceObject, PowerRelations);
 
 exit:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 
@@ -4088,7 +4088,7 @@ CAdapterCommon::RemoveDeviceAsPowerDependency
 
     IoInvalidateDeviceRelations(m_pPhysicalDeviceObject, PowerRelations);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return status;
 }
 
@@ -4105,14 +4105,14 @@ Cleanup the USB Sideband environment.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
     // Do nothing if USB Sideband environment was not correctly initialized.
     //
     if (m_UsbSidebandEnableCleanup == FALSE)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
 
@@ -4192,13 +4192,13 @@ WorkItem    - WDF work-item object.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     CAdapterCommon        * This;
 
     if (WorkItem == NULL)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
 
@@ -4285,7 +4285,7 @@ A2dpSidebandDevice pointer or NULL.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     PLIST_ENTRY     le = NULL;
     A2dpHpDevice  * a2dpDevice = NULL;
@@ -4312,7 +4312,7 @@ A2dpSidebandDevice pointer or NULL.
 
     ExReleaseFastMutex(&m_A2dpSidebandFastMutex);
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return a2dpDevice;
 }
 
@@ -4340,7 +4340,7 @@ NT status code.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS            ntStatus = STATUS_SUCCESS;
     A2dpHpDevice         *a2dpHpDevice = NULL;
@@ -4436,7 +4436,7 @@ Done:
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -4464,7 +4464,7 @@ NT status code.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS            ntStatus = STATUS_SUCCESS;
     A2dpHpDevice         *a2dpHpDevice = NULL;
@@ -4537,7 +4537,7 @@ Done:
         SAFE_RELEASE(a2dpHpDevice);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -4565,7 +4565,7 @@ NT status code.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                              ntStatus = STATUS_SUCCESS;
     CAdapterCommon                      * This = NULL;
@@ -4610,7 +4610,7 @@ NT status code.
     }
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -4631,7 +4631,7 @@ NT status code.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                ntStatus = STATUS_SUCCESS;
     WDF_WORKITEM_CONFIG     wiConfig;
@@ -4726,7 +4726,7 @@ NT status code.
 
 Done:
     RtlFreeUnicodeString(&sidebandSupportRefString);
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -4743,14 +4743,14 @@ Cleanup the A2DP Sideband environment.
 --*/
 {
     PAGED_CODE();
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
     // Do nothing if A2DP Sideband environment was not correctly initialized.
     //
     if (m_A2dpSidebandEnableCleanup == FALSE)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return;
     }
 
@@ -4900,7 +4900,7 @@ Exit:
         ExFreePoolWithTag(kvFullInfo, MINADAPTER_POOLTAG);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -5040,7 +5040,7 @@ Exit:
     {
         ExFreePoolWithTag(kBasicInfo, MINADAPTER_POOLTAG);
     }
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -5094,7 +5094,7 @@ Return Value:
 
     //
     // Register an audio interface if not already present for the template interface, so we can access
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     // the registry path. If it's already registered, this simply returns the symbolic link name. 
     // No need to unregister it (there is no mechanism to), and we'll never make it active.
     //
@@ -5129,7 +5129,7 @@ Exit:
         ZwClose(hDeviceInterfaceParametersKey);
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 
@@ -5170,7 +5170,7 @@ CAdapterCommon::NotifyEndpointPair
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 }
 

--- a/sysvad/kshelper.cpp
+++ b/sysvad/kshelper.cpp
@@ -631,7 +631,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
 
@@ -655,7 +655,7 @@ Return Value:
             );
     }
 
-    DPF_EXIT(("[%s]",__FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerCpuResources
 
@@ -690,7 +690,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG    ulChannel;
@@ -763,7 +763,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]",__FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerVolume
 
@@ -798,7 +798,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS                    ntStatus;
     ULONG                       ulChannel;
@@ -871,7 +871,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]",__FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerMute
 
@@ -906,7 +906,7 @@ Return Value:
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]",__FUNCTION__));
+    DPF_ENTER();
 
     NTSTATUS ntStatus = STATUS_INVALID_DEVICE_REQUEST;
     ULONG    ulChannel;
@@ -957,7 +957,7 @@ Return Value:
         }
     }
 
-    DPF_EXIT(("[%s]",__FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // PropertyHandlerVolume
 

--- a/sysvad/savedata.cpp
+++ b/sysvad/savedata.cpp
@@ -101,7 +101,7 @@ CSaveData::~CSaveData()
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     //
     // All write activity is done at this point (see acquire->stop stream transition).
@@ -164,7 +164,7 @@ CSaveData::~CSaveData()
         ExFreePoolWithTag(m_pDataBuffer, SAVEDATA_POOLTAG4);
         m_pDataBuffer = NULL;
     }
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 } // CSaveData
 
 //=============================================================================
@@ -470,7 +470,7 @@ CSaveData::Initialize
     OBJECT_ATTRIBUTES   objectAttributes;
     UNICODE_STRING      fileName;
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     if (_bOffloaded)
     {
@@ -664,7 +664,7 @@ CSaveData::Initialize
         }
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // Initialize
 
@@ -681,11 +681,11 @@ CSaveData::InitializeWorkItems
 
     NTSTATUS                    ntStatus = STATUS_SUCCESS;
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     if (m_pWorkItems != NULL)
     {
-        DPF_EXIT(("[%s]", __FUNCTION__));
+        DPF_EXIT();
         return ntStatus;
     }
 
@@ -704,7 +704,7 @@ CSaveData::InitializeWorkItems
             m_pWorkItems[i].WorkItem = IoAllocateWorkItem(DeviceObject);
             if(m_pWorkItems[i].WorkItem == NULL)
             {
-              DPF_EXIT(("[%s]", __FUNCTION__));
+              DPF_EXIT();
               return STATUS_INSUFFICIENT_RESOURCES;
             }
             KeInitializeEvent
@@ -720,7 +720,7 @@ CSaveData::InitializeWorkItems
         ntStatus = STATUS_INSUFFICIENT_RESOURCES;
     }
 
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // InitializeWorkItems
 
@@ -794,7 +794,7 @@ CSaveData::SetDataFormat
     PAGED_CODE();
     NTSTATUS                    ntStatus = STATUS_SUCCESS;
  
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     ASSERT(pDataFormat);
 
@@ -843,7 +843,7 @@ CSaveData::SetDataFormat
             ntStatus = STATUS_INSUFFICIENT_RESOURCES;
         }
     }
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // SetDataFormat
 
@@ -860,7 +860,7 @@ CSaveData::SetMaxWriteSize
     ULONG       bufferSize  = 0;
     PBYTE       buffer      = NULL;
  
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // 
     // Compute new buffer size.
@@ -909,7 +909,7 @@ CSaveData::SetMaxWriteSize
     ntStatus = STATUS_SUCCESS;
 
 Done:
-    DPF_EXIT(("[%s]", __FUNCTION__));
+    DPF_EXIT();
     return ntStatus;
 } // SetDataFormat
 
@@ -940,7 +940,7 @@ CSaveData::SaveFrame
 {
     PSAVEWORKER_PARAM           pParam = NULL;
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     pParam = GetNewWorkItem();
     if (pParam)
@@ -952,7 +952,7 @@ CSaveData::SaveFrame
         IoQueueWorkItem(pParam->WorkItem, SaveFrameWorkerCallback,
                         CriticalWorkQueue, (PVOID)pParam);
     }
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 } // SaveFrame
 #pragma code_seg("PAGE")
 //=============================================================================
@@ -964,7 +964,7 @@ CSaveData::WaitAllWorkItems
 {
     PAGED_CODE();
 
-    DPF_ENTER(("[%s]", __FUNCTION__));
+    DPF_ENTER();
 
     // Save the last partially-filled frame
     if (m_ulBufferOffset > m_ulFrameIndex * m_ulFrameSize)
@@ -987,7 +987,7 @@ CSaveData::WaitAllWorkItems
             NULL
         );
     }
-DPF_EXIT(("[%s]", __FUNCTION__));
+DPF_EXIT();
 } // WaitAllWorkItems
 
 #pragma code_seg()
@@ -1012,11 +1012,11 @@ CSaveData::WriteData
         return;
     }
 
-    DPF_ENTER(("[%s ulByteCount=%lu]", __FUNCTION__, ulByteCount));
+    DPF_ENTER();
 
     if( 0 == ulByteCount )
     {
-        DPF_EXIT(("[%s ulByteCount=%lu]", __FUNCTION__, ulByteCount));
+        DPF_EXIT();
         return;
     }
 

--- a/sysvad/sysvad.h
+++ b/sysvad/sysvad.h
@@ -55,8 +55,8 @@ DEFINE_GUIDSTRUCT("5B722BF8-F0AB-47ee-B9C8-8D61D31375A1", PID_SYSVAD);
 #define D_TERSE                     DEBUGLVL_TERSE          
 #define D_ERROR                     DEBUGLVL_ERROR          
 #define DPF                         _DbgPrintF
-#define DPF_ENTER                   DPF(D_FUNC, ("Enter:[%s]", __FUNCTION__))
-#define DPF_EXIT                    DPF(D_FUNC, ("Exit:[%s] at Line(%d)", __FUNCTION__,__LILNE__))
+#define DPF_ENTER()                 DPF(D_FUNC, ("Enter:[%s]", __FUNCTION__))
+#define DPF_EXIT()                  DPF(D_FUNC, ("Exit:[%s] at Line(%d)", __FUNCTION__, __LINE__))
 // Channel orientation
 #define CHAN_LEFT                   0
 #define CHAN_RIGHT                  1


### PR DESCRIPTION
## Summary
- refactor all DPF_ENTER/DPF_EXIT invocations
- make DPF_ENTER/EXIT no longer require manual parameters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6849188baa008324a2025745d3ff6233