### PR TITLE
Add audio playback command in Test folder

### DIFF
--- a/Test/README.md
+++ b/Test/README.md
@@ -1,0 +1,24 @@
+# Test Audio Playback Application
+
+This folder contains a simple Python command-line application that plays an
+audio file to a specified output device using the `sounddevice` module.
+
+## Requirements
+
+- Python 3
+- [`sounddevice`](https://python-sounddevice.readthedocs.io/)
+- [`soundfile`](https://pysoundfile.readthedocs.io/)
+
+Install dependencies with:
+
+```sh
+pip install sounddevice soundfile
+```
+
+## Usage
+
+```sh
+python play_audio.py <audio-file> --device <device-name-or-id>
+```
+
+Use `python -m sounddevice` to list available devices.

--- a/Test/play_audio.py
+++ b/Test/play_audio.py
@@ -1,0 +1,25 @@
+import argparse
+import sounddevice as sd
+import soundfile as sf
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Playback an audio file to a specified speaker")
+    parser.add_argument("filename", help="Path to audio file")
+    parser.add_argument(
+        "-d",
+        "--device",
+        type=str,
+        default=None,
+        help="Output device name or index (see sounddevice.query_devices())",
+    )
+    args = parser.parse_args()
+
+    data, samplerate = sf.read(args.filename, dtype="float32")
+    sd.play(data, samplerate, device=args.device)
+    sd.wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `Test` folder
- implement `play_audio.py` for audio playback
- document usage and requirements in README

## Testing
- `python -m py_compile Test/play_audio.py`

------
https://chatgpt.com/codex/tasks/task_b_6849c98b32908324b4b64a2f7d948d20