### PR TITLE
Update output format instructions

### DIFF
--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -19,3 +19,17 @@ When started, the program lists all active speaker devices and lets the
 user choose one. Audio from the SysVAD loopback driver is streamed to
 the selected device. If an output file is supplied, the same PCM data is
 also written to that file.
+
+## Output format
+The optional `output.raw` file contains raw PCM samples with no WAV header.
+`folkaurixsvc` prints the sample rate, bit depth and channel count on
+startup, which you can use when converting the file.
+
+To convert the raw PCM to a WAV file with `ffmpeg`:
+
+```sh
+ffmpeg -f s16le -ar 48000 -ac 2 -i output.raw output.wav
+```
+
+Replace the sample format, rate and channel count with the values printed
+by the application when it starts.


### PR DESCRIPTION
## Summary
- clarify that `output.raw` is plain PCM without a WAV header
- note that `folkaurixsvc` prints the sample rate, bit depth and channel count
- add an `ffmpeg` example for converting to a WAV file

## Testing
- `python3 -m py_compile Test/play_audio.py`


------
https://chatgpt.com/codex/tasks/task_b_684b8fa04e308324af68800890d36431