### PR TITLE
Add hotkey and raw to wav conversion

### DIFF
--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -18,4 +18,6 @@ folkaurixsvc.exe [output.raw]
 When started, the program lists all active speaker devices and lets the
 user choose one. Audio from the SysVAD loopback driver is streamed to
 the selected device. If an output file is supplied, the same PCM data is
-also written to that file.
+also written to that file. Press **F9** during capture to stop the
+program. If an output file was specified, it will automatically be
+converted from raw PCM to a `.wav` file when capture stops.


### PR DESCRIPTION
## Summary
- add `ConvertRawToWav` helper to convert captured raw audio to WAV
- detect F9 key during capture loop and exit gracefully
- after exiting, automatically convert the raw capture file to WAV
- document new hotkey in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_684b9042ef70832496ff8faa987adfe3