### PR TITLE
Fix missing MixerPeakMeterWrite declaration

### DIFF
--- a/sysvad/common.cpp
+++ b/sysvad/common.cpp
@@ -183,9 +183,16 @@ class CAdapterCommon :
         );
 
         STDMETHODIMP_(LONG)     MixerPeakMeterRead
-        ( 
+        (
             _In_  ULONG           Index,
             _In_  ULONG           Channel
+        );
+
+        STDMETHODIMP_(void)     MixerPeakMeterWrite
+        (
+            _In_  ULONG           Index,
+            _In_  ULONG           Channel,
+            _In_  LONG            Value
         );
 
         STDMETHODIMP_(NTSTATUS) WriteEtwEvent 


### PR DESCRIPTION
## Summary
- implement MixerPeakMeterWrite in the CAdapterCommon class definition to match the interface

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684b911f2b708324884a88c86eb58445