### PR TITLE
Fix C++17 setting for folkaurixsvc

### DIFF
--- a/folkaurixsvc/folkaurixsvc.vcxproj
+++ b/folkaurixsvc/folkaurixsvc.vcxproj
@@ -28,6 +28,16 @@
     <PlatformToolset>v143</PlatformToolset>
     <LanguageStandard>stdcpp17</LanguageStandard>
   </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />


### PR DESCRIPTION
## Summary
- force the C++17 language standard in `folkaurixsvc.vcxproj`

## Testing
- `python -m py_compile Test/play_audio.py`

------
https://chatgpt.com/codex/tasks/task_b_684c68061f1883249d526ba5f8a3ecdd