### PR TITLE
Fix build errors by adjusting header order

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -1,6 +1,8 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #include <windows.h>
 #include <stdio.h>
 #include <mmdeviceapi.h>


### PR DESCRIPTION
## Summary
- include Winsock2 headers before `windows.h` to avoid redefinition errors during build

## Testing
- `python3 -m py_compile Test/play_audio.py`


------
https://chatgpt.com/codex/tasks/task_b_684c6b508fc88324acc061f0ec1072b6