### PR TITLE
Enable automatic language detection

### DIFF
--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -24,6 +24,8 @@ If a file was specified, it is automatically converted from raw PCM to a
 sent to Google Cloud for speech recognition, translation and
 text‑to‑speech synthesis. The synthesized audio is played back to the
 previously selected render device. `-l` allows specifying the ISO
-language code used for translation (default `zh`). The WAV header is now
-written using the driver stream's fixed format (48 kHz, 16‑bit stereo) so
-it can be played directly.
+language code used for translation (default `zh`). The speech recognizer
+now attempts to automatically detect the input language. By default it
+listens for English, Spanish, French, German, Japanese and Mandarin.
+The WAV header is written using the driver stream's fixed format
+(48 kHz, 16‑bit stereo) so it can be played directly.

--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -109,6 +109,13 @@ bool ProcessAudioWithGoogle(const std::wstring& wavPath,
     recConfig.set_encoding(RecognitionConfig::LINEAR16);
     recConfig.set_sample_rate_hertz(48000);
     recConfig.set_language_code("en-US");
+    // Enable automatic language detection with a set of defaults.
+    // The recognizer will pick the best match among these languages.
+    recConfig.add_alternative_language_codes("es-ES"); // Spanish
+    recConfig.add_alternative_language_codes("fr-FR"); // French
+    recConfig.add_alternative_language_codes("de-DE"); // German
+    recConfig.add_alternative_language_codes("ja-JP"); // Japanese
+    recConfig.add_alternative_language_codes("cmn-Hans-CN"); // Mandarin
     RecognitionAudio audio;
     audio.set_content(std::string(wavData.begin(), wavData.end()));
 
@@ -128,7 +135,6 @@ bool ProcessAudioWithGoogle(const std::wstring& wavPath,
     request.set_parent("projects/-/locations/global");
     request.add_contents(transcript);
     request.set_target_language_code(targetLanguage);
-    request.set_source_language_code("en");
     auto transResp = transClient.TranslateText(request);
     if (!transResp) return false;
     std::string translatedText;


### PR DESCRIPTION
## Summary
- enable Speech-to-Text automatic language detection with common languages
- let the translation service detect the source language
- document the new behavior in the service README

## Testing
- `python3 -m py_compile Test/play_audio.py`

------
https://chatgpt.com/codex/tasks/task_b_684cbf9c83f48324bb28c2e4ef8f5b74