### PR TITLE
Fix google speech test for stereo WAV files

### DIFF
--- a/Test/README.md
+++ b/Test/README.md
@@ -51,3 +51,15 @@ Options:
 * `-?` or `--help`  Show help
 
 Press `Ctrl+C` to stop the program.
+
+## Google Speech Test Script
+
+`test_google_speech.py` sends a WAV file to Google Cloud Speech-to-Text and
+prints the recognised text. The script automatically converts stereo input to
+mono so you can use a regular two-channel recording.
+
+```sh
+python test_google_speech.py <audio.wav> <credentials.json> [--language CODE]
+```
+
+The sample rate is detected from the WAV header unless `--rate` is supplied.

--- a/Test/test_google_speech.py
+++ b/Test/test_google_speech.py
@@ -2,10 +2,23 @@
 """Send a WAV file to Google Cloud Speech-to-Text and print the transcript."""
 
 import argparse
-import io
 import os
+import wave
+import audioop
 
 from google.cloud import speech
+
+
+def load_wav_mono(path: str) -> tuple[bytes, int]:
+    """Read a WAV file and return mono PCM data and sample rate."""
+    with wave.open(path, "rb") as wf:
+        params = wf.getparams()
+        frames = wf.readframes(params.nframes)
+
+    if params.nchannels != 1:
+        frames = audioop.tomono(frames, params.sampwidth, 0.5, 0.5)
+
+    return frames, params.framerate
 
 
 def main() -> None:
@@ -19,7 +32,8 @@ def main() -> None:
         "--language", default="en-US", help="Language code of the audio (default: en-US)"
     )
     parser.add_argument(
-        "--rate", type=int, default=16000, help="Sample rate in Hz (default: 16000)"
+        "--rate", type=int, default=None,
+        help="Sample rate in Hz. Defaults to the rate in the WAV file"
     )
     args = parser.parse_args()
 
@@ -27,14 +41,13 @@ def main() -> None:
 
     client = speech.SpeechClient()
 
-    with io.open(args.audio, "rb") as f:
-        content = f.read()
+    audio_data, file_rate = load_wav_mono(args.audio)
 
-    audio = speech.RecognitionAudio(content=content)
+    audio = speech.RecognitionAudio(content=audio_data)
     config = speech.RecognitionConfig(
         encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
         language_code=args.language,
-        sample_rate_hertz=args.rate,
+        sample_rate_hertz=args.rate or file_rate,
     )
 
     response = client.recognize(config=config, audio=audio)


### PR DESCRIPTION
## Summary
- convert stereo WAVs to mono before sending to Google STT
- detect sample rate from the WAV header
- document google speech test script

## Testing
- `python -m py_compile Test/test_google_speech.py`

------
https://chatgpt.com/codex/tasks/task_b_684ceed7ebd88324b05c6129ce87ed88