### PR TITLE
Handle F9 cancel for reader thread

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -493,6 +493,8 @@ std::thread writer([&] {
     std::thread tts(TtsThread, targetLang, ttsEncoding, ttsRate);
 
     writer.join();
+    // Cancel the stream to unblock the reader if it is waiting
+    streamer->Cancel();
     reader.join();
     g_cv.notify_all();
     translator.join();
@@ -795,6 +797,8 @@ int wmain(int argc, wchar_t** argv)
         if (GetAsyncKeyState(VK_F9) & 0x8000)
         {
             stopRequested = true;
+            g_stop = true;
+            g_cv.notify_all();
             continue;
         }
 


### PR DESCRIPTION
## Summary
- cancel gRPC stream so reader thread exits once F9 is pressed

## Testing
- `python3 -m py_compile Test/play_audio.py Test/test_google_speech.py`


------
https://chatgpt.com/codex/tasks/task_b_684e42278204832489b30fb835668a00