### PR TITLE
Add queue clearing when stopping

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -51,6 +51,15 @@ static std::mutex g_mutex;
 static std::condition_variable g_cv;
 static bool g_stop = false;
 
+void ClearAllQueues()
+{
+    std::lock_guard<std::mutex> lk(g_mutex);
+    while (!g_captureQueue.empty()) g_captureQueue.pop();
+    while (!g_transcriptQueue.empty()) g_transcriptQueue.pop();
+    while (!g_translationQueue.empty()) g_translationQueue.pop();
+    while (!g_ttsQueue.empty()) g_ttsQueue.pop();
+}
+
 bool ConvertRawToWav(const wchar_t* rawPath,
                      const wchar_t* wavPath,
                      const WAVEFORMATEX* pwfx)
@@ -816,6 +825,7 @@ int wmain(int argc, wchar_t** argv)
             stopRequested = true;
             g_stop = true;
             g_cv.notify_all();
+            ClearAllQueues();
             continue;
         }
 
@@ -876,6 +886,7 @@ int wmain(int argc, wchar_t** argv)
     g_cv.notify_all();
     pipeline.join();
     playback.join();
+    ClearAllQueues();
 
     pRenderClient->Release();
     CloseHandle(hAudioEvent);


### PR DESCRIPTION
## Summary
- ensure pressing **F9** fully stops the service
- clear all audio processing queues when F9 is pressed and after threads exit

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_b_684e49a99498832495635886b45d1409