### PR TITLE
Stop TTS streaming on stop

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -227,8 +227,13 @@ void TtsThread(const std::string& targetLang,
 
         // --- Read the audio chunks from the server ---
         while (true) {
+            if (g_stop) {
+                stream->Cancel();
+                break;
+            }
+
             auto chunk_opt = stream->Read().get();
-            if (!chunk_opt) break; 
+            if (!chunk_opt) break;
 
             ::google::cloud::texttospeech::v1::StreamingSynthesizeResponse const& response = *chunk_opt;
             if (!response.audio_content().empty()) {


### PR DESCRIPTION
## Summary
- interrupt Google TTS streaming when `g_stop` is set so no more audio is queued

## Testing
- `python -m py_compile Test/play_audio.py`
- `python -m py_compile Test/test_google_speech.py`


------
https://chatgpt.com/codex/tasks/task_b_684e531419788324b73a79eb71d0c010