### PR TITLE
Fix azure build issues by defining C++20 macro

### DIFF
--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -9,9 +9,11 @@ played back through a user selected audio render device.  Optionally the
 raw PCM data can also be written to a file.
 
 ## Building
-The project is a standard Visual Studio console application.  Add
-`folkaurixsvc.cpp` to a new Win32 project and build for x64 or any
-desired architecture.
+The project is a standard Visual Studio console application. Add
+`folkaurixsvc.cpp` to a new Win32 project and build for x64 (or any desired
+architecture). When using the Azure Speech SDK version 1.44 or newer the
+compiler must support the C++20 language standard. Ensure the `/Zc:__cplusplus`
+option is enabled so the SDK detects that C++20 features are available.
 
 ## Usage
 ```

--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -466,9 +466,10 @@ bool StartAzurePipeline(const std::string& targetLang)
     });
 
     recognizer->Recognized.Connect([&](const TranslationRecognitionEventArgs& e) {
-        if (e.Result.Reason == ResultReason::TranslatedSpeech) {
-            auto it = e.Result.Translations.find(targetLang);
-            if (it != e.Result.Translations.end()) {
+        auto result = e.Result;
+        if (result && result->Reason == ResultReason::TranslatedSpeech) {
+            auto it = result->Translations.find(targetLang);
+            if (it != result->Translations.end()) {
                 auto text = it->second;
                 auto ttsConfig = SpeechConfig::FromSubscription(AZURE_KEY, AZURE_REGION);
                 ttsConfig->SetSpeechSynthesisLanguage(targetLang.c_str());
@@ -789,8 +790,8 @@ int wmain(int argc, wchar_t** argv)
     DPF(L"Press F9 to stop recording...\n");
 
     std::thread playback(PlaybackThread, pAudioClient, pRenderClient, renderFormat);
-    auto ttsEncoding = EncodingFromWaveFormat(renderFormat);
 #if API==GOOGLE
+    auto ttsEncoding = EncodingFromWaveFormat(renderFormat);
     std::thread pipeline(StartRealtimePipeline, targetLang, ttsEncoding, renderFormat.nSamplesPerSec);
 #elif API==Azure
     std::thread pipeline(StartAzurePipeline, targetLang);

--- a/folkaurixsvc/folkaurixsvc.vcxproj
+++ b/folkaurixsvc/folkaurixsvc.vcxproj
@@ -20,22 +20,24 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <LanguageStandard>stdcpp17</LanguageStandard>
+    <LanguageStandard>stdcpp20</LanguageStandard>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <LanguageStandard>stdcpp17</LanguageStandard>
+    <LanguageStandard>stdcpp20</LanguageStandard>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <Zc__cplusplus>true</Zc__cplusplus>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <Zc__cplusplus>true</Zc__cplusplus>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
## Summary
- enable `/Zc:__cplusplus` so Azure SDK sees C++20
- mention this flag in the build instructions
- fix Azure pipeline: handle result pointer and wrap encoding helper

## Testing
- `python3 -m py_compile Test/test_google_speech.py`


------
https://chatgpt.com/codex/tasks/task_b_684f1e9da1988324b84f1614ddc5096e