### PR TITLE
Adjust render format to 16k mono

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -298,10 +298,10 @@ bool StartRealtimePipeline(const std::string& targetLang,
     streamCfg.set_enable_voice_activity_events(true);
     auto* recCfg = streamCfg.mutable_config();
     recCfg->set_encoding(RecognitionConfig::LINEAR16);
-    // Configure streaming recognition for 48 kHz stereo audio.
-    recCfg->set_sample_rate_hertz(48000);
+    // Configure streaming recognition for 16 kHz mono audio.
+    recCfg->set_sample_rate_hertz(16000);
     recCfg->set_language_code("en-US");
-    recCfg->set_audio_channel_count(2);
+    recCfg->set_audio_channel_count(1);
     recCfg->set_enable_separate_recognition_per_channel(false);
     recCfg->add_alternative_language_codes("es-ES");
     recCfg->add_alternative_language_codes("fr-FR");
@@ -719,11 +719,11 @@ int wmain(int argc, wchar_t** argv)
 
     WAVEFORMATEX renderFormat = *pwfx;
 
-    // SysVAD loopback streams audio in a fixed 2ch/16-bit/48kHz format.
+    // SysVAD loopback streams audio in a fixed 1ch/16-bit/16kHz format.
     WAVEFORMATEX captureFormat = {};
     captureFormat.wFormatTag = WAVE_FORMAT_PCM;
-    captureFormat.nChannels = 2;
-    captureFormat.nSamplesPerSec = 48000;
+    captureFormat.nChannels = 1;
+    captureFormat.nSamplesPerSec = 16000;
     captureFormat.wBitsPerSample = 16;
     captureFormat.nBlockAlign =
         captureFormat.nChannels * captureFormat.wBitsPerSample / 8;

--- a/sysvad/EndpointsCommon/speakerhpwavtable.h
+++ b/sysvad/EndpointsCommon/speakerhpwavtable.h
@@ -19,21 +19,21 @@ Abstract:
 #include "AudioModule1.h"
 #include "AudioModule2.h"
 
-// To keep the code simple assume device supports only 48KHz, 16-bit, stereo (PCM and NON-PCM)
+// To keep the code simple assume device supports only 16KHz, 16-bit, mono (PCM and NON-PCM)
 
-#define SPEAKERHP_DEVICE_MAX_CHANNELS                   2       // Max Channels.
+#define SPEAKERHP_DEVICE_MAX_CHANNELS                   1       // Max Channels.
 
-#define SPEAKERHP_HOST_MAX_CHANNELS                     2       // Max Channels.
+#define SPEAKERHP_HOST_MAX_CHANNELS                     1       // Max Channels.
 #define SPEAKERHP_HOST_MIN_BITS_PER_SAMPLE              16      // Min Bits Per Sample
 #define SPEAKERHP_HOST_MAX_BITS_PER_SAMPLE              16      // Max Bits Per Sample
-#define SPEAKERHP_HOST_MIN_SAMPLE_RATE                  24000   // Min Sample Rate
-#define SPEAKERHP_HOST_MAX_SAMPLE_RATE                  96000   // Max Sample Rate
+#define SPEAKERHP_HOST_MIN_SAMPLE_RATE                  16000   // Min Sample Rate
+#define SPEAKERHP_HOST_MAX_SAMPLE_RATE                  16000   // Max Sample Rate
 
-#define SPEAKERHP_OFFLOAD_MAX_CHANNELS                  2       // Max Channels.
+#define SPEAKERHP_OFFLOAD_MAX_CHANNELS                  1       // Max Channels.
 #define SPEAKERHP_OFFLOAD_MIN_BITS_PER_SAMPLE           16      // Min Bits Per Sample
 #define SPEAKERHP_OFFLOAD_MAX_BITS_PER_SAMPLE           16      // Max Bits Per Sample
-#define SPEAKERHP_OFFLOAD_MIN_SAMPLE_RATE               44100   // Min Sample Rate
-#define SPEAKERHP_OFFLOAD_MAX_SAMPLE_RATE               48000   // Max Sample Rate
+#define SPEAKERHP_OFFLOAD_MIN_SAMPLE_RATE               16000   // Min Sample Rate
+#define SPEAKERHP_OFFLOAD_MAX_SAMPLE_RATE               16000   // Max Sample Rate
 
 #define SPEAKERHP_LOOPBACK_MAX_CHANNELS                 SPEAKERHP_HOST_MAX_CHANNELS          // Must be equal to host pin's Max Channels.
 #define SPEAKERHP_LOOPBACK_MIN_BITS_PER_SAMPLE          SPEAKERHP_HOST_MIN_BITS_PER_SAMPLE   // Must be equal to host pin's Min Bits Per Sample
@@ -41,11 +41,11 @@ Abstract:
 #define SPEAKERHP_LOOPBACK_MIN_SAMPLE_RATE              SPEAKERHP_HOST_MIN_SAMPLE_RATE       // Must be equal to host pin's Min Sample Rate
 #define SPEAKERHP_LOOPBACK_MAX_SAMPLE_RATE              SPEAKERHP_HOST_MAX_SAMPLE_RATE       // Must be equal to host pin's Max Sample Rate
 
-#define SPEAKERHP_DOLBY_DIGITAL_MAX_CHANNELS            2       // Max Channels.
+#define SPEAKERHP_DOLBY_DIGITAL_MAX_CHANNELS            1       // Max Channels.
 #define SPEAKERHP_DOLBY_DIGITAL_MIN_BITS_PER_SAMPLE     16      // Min Bits Per Sample
 #define SPEAKERHP_DOLBY_DIGITAL_MAX_BITS_PER_SAMPLE     16      // Max Bits Per Sample
-#define SPEAKERHP_DOLBY_DIGITAL_MIN_SAMPLE_RATE         44100   // Min Sample Rate
-#define SPEAKERHP_DOLBY_DIGITAL_MAX_SAMPLE_RATE         44100   // Max Sample Rate
+#define SPEAKERHP_DOLBY_DIGITAL_MIN_SAMPLE_RATE         16000   // Min Sample Rate
+#define SPEAKERHP_DOLBY_DIGITAL_MAX_SAMPLE_RATE         16000   // Max Sample Rate
 
 //
 // Max # of pin instances.
@@ -71,15 +71,15 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpAudioEngineSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                44100,
-                176400,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
             16,
-            KSAUDIO_SPEAKER_STEREO,
+            KSAUDIO_SPEAKER_MONO,
             STATICGUIDOF(KSDATAFORMAT_SUBTYPE_PCM)
         }
     },
@@ -96,10 +96,10 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpAudioEngineSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                24000,
-                96000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE)-sizeof(WAVEFORMATEX)
             },
@@ -121,10 +121,10 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpAudioEngineSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                48000,
-                192000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
@@ -146,10 +146,10 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpAudioEngineSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                88200,
-                352800,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
@@ -171,10 +171,10 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpAudioEngineSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                96000,
-                384000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
@@ -201,15 +201,15 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpHostPinSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                24000,
-                96000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE)-sizeof(WAVEFORMATEX)
             },
             16,
-            KSAUDIO_SPEAKER_STEREO,
+            KSAUDIO_SPEAKER_MONO,
             STATICGUIDOF(KSDATAFORMAT_SUBTYPE_PCM)
         }
     },
@@ -252,9 +252,9 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpHostPinSupportedDeviceFormats[] =
             {
                 WAVE_FORMAT_EXTENSIBLE,
                 2,
-                44100,
-                176400,
-                4,
+                16000,
+                32000,
+                2,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE)-sizeof(WAVEFORMATEX)
             },
@@ -276,10 +276,10 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpHostPinSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                48000,
-                192000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
@@ -301,10 +301,10 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpHostPinSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                88200,
-                352800,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
@@ -326,10 +326,10 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpHostPinSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                96000,
-                384000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
@@ -356,15 +356,15 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpOffloadPinSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                44100,
-                176400,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
             16,
-            KSAUDIO_SPEAKER_STEREO,
+            KSAUDIO_SPEAKER_MONO,
             STATICGUIDOF(KSDATAFORMAT_SUBTYPE_PCM)
         }
     },
@@ -381,10 +381,10 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHpOffloadPinSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                48000,
-                192000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
@@ -403,27 +403,27 @@ MODE_AND_DEFAULT_FORMAT SpeakerHpHostPinSupportedDeviceModes[] =
 {
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_RAW,
-        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 48KHz
+        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_DEFAULT,
-        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 48KHz
+        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_MEDIA,
-        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 48KHz
+        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_MOVIE,
-        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 48KHz
+        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_COMMUNICATIONS,
-        &SpeakerHpHostPinSupportedDeviceFormats[0].DataFormat // 24KHz
+        &SpeakerHpHostPinSupportedDeviceFormats[0].DataFormat // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_NOTIFICATION,
-        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 48KHz
+        &SpeakerHpHostPinSupportedDeviceFormats[3].DataFormat // 16KHz
     }
 };
 
@@ -432,11 +432,11 @@ MODE_AND_DEFAULT_FORMAT SpeakerHpOffloadPinSupportedDeviceModes[] =
 {
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_DEFAULT,
-        &SpeakerHpOffloadPinSupportedDeviceFormats[1].DataFormat // 48KHz
+        &SpeakerHpOffloadPinSupportedDeviceFormats[1].DataFormat // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_MEDIA,
-        &SpeakerHpOffloadPinSupportedDeviceFormats[1].DataFormat // 48KHz
+        &SpeakerHpOffloadPinSupportedDeviceFormats[1].DataFormat // 16KHz
     }
 };
 

--- a/sysvad/EndpointsCommon/speakerwavtable.h
+++ b/sysvad/EndpointsCommon/speakerwavtable.h
@@ -19,21 +19,21 @@ Abstract:
 #include "AudioModule0.h"
 #include "AudioModule1.h"
 
-// To keep the code simple assume device supports only 48KHz, 16-bit, stereo (PCM and NON-PCM)
+// To keep the code simple assume device supports only 16KHz, 16-bit, mono (PCM and NON-PCM)
 
-#define SPEAKER_DEVICE_MAX_CHANNELS                 2       // Max Channels.
+#define SPEAKER_DEVICE_MAX_CHANNELS                 1       // Max Channels.
 
-#define SPEAKER_HOST_MAX_CHANNELS                   2       // Max Channels.
+#define SPEAKER_HOST_MAX_CHANNELS                   1       // Max Channels.
 #define SPEAKER_HOST_MIN_BITS_PER_SAMPLE            16      // Min Bits Per Sample
 #define SPEAKER_HOST_MAX_BITS_PER_SAMPLE            16      // Max Bits Per Sample
-#define SPEAKER_HOST_MIN_SAMPLE_RATE                48000   // Min Sample Rate
-#define SPEAKER_HOST_MAX_SAMPLE_RATE                48000   // Max Sample Rate
+#define SPEAKER_HOST_MIN_SAMPLE_RATE                16000   // Min Sample Rate
+#define SPEAKER_HOST_MAX_SAMPLE_RATE                16000   // Max Sample Rate
 
-#define SPEAKER_OFFLOAD_MAX_CHANNELS                2       // Max Channels.
+#define SPEAKER_OFFLOAD_MAX_CHANNELS                1       // Max Channels.
 #define SPEAKER_OFFLOAD_MIN_BITS_PER_SAMPLE         16      // Min Bits Per Sample
 #define SPEAKER_OFFLOAD_MAX_BITS_PER_SAMPLE         16      // Max Bits Per Sample
-#define SPEAKER_OFFLOAD_MIN_SAMPLE_RATE             48000   // Min Sample Rate
-#define SPEAKER_OFFLOAD_MAX_SAMPLE_RATE             48000   // Max Sample Rate
+#define SPEAKER_OFFLOAD_MIN_SAMPLE_RATE             16000   // Min Sample Rate
+#define SPEAKER_OFFLOAD_MAX_SAMPLE_RATE             16000   // Max Sample Rate
 
 #define SPEAKER_LOOPBACK_MAX_CHANNELS               SPEAKER_HOST_MAX_CHANNELS       // Must be equal to host pin's Max Channels.
 #define SPEAKER_LOOPBACK_MIN_BITS_PER_SAMPLE        SPEAKER_HOST_MIN_BITS_PER_SAMPLE   // Must be equal to host pin's Min Bits Per Sample
@@ -41,11 +41,11 @@ Abstract:
 #define SPEAKER_LOOPBACK_MIN_SAMPLE_RATE            SPEAKER_HOST_MIN_SAMPLE_RATE       // Must be equal to host pin's Min Sample Rate
 #define SPEAKER_LOOPBACK_MAX_SAMPLE_RATE            SPEAKER_HOST_MAX_SAMPLE_RATE       // Must be equal to host pin's Max Sample Rate
 
-#define SPEAKER_DOLBY_DIGITAL_MAX_CHANNELS          2       // Max Channels.
+#define SPEAKER_DOLBY_DIGITAL_MAX_CHANNELS          1       // Max Channels.
 #define SPEAKER_DOLBY_DIGITAL_MIN_BITS_PER_SAMPLE   16      // Min Bits Per Sample
 #define SPEAKER_DOLBY_DIGITAL_MAX_BITS_PER_SAMPLE   16      // Max Bits Per Sample
-#define SPEAKER_DOLBY_DIGITAL_MIN_SAMPLE_RATE       48000   // Min Sample Rate
-#define SPEAKER_DOLBY_DIGITAL_MAX_SAMPLE_RATE       48000   // Max Sample Rate
+#define SPEAKER_DOLBY_DIGITAL_MIN_SAMPLE_RATE       16000   // Min Sample Rate
+#define SPEAKER_DOLBY_DIGITAL_MAX_SAMPLE_RATE       16000   // Max Sample Rate
 
 //
 // Max # of pin instances.
@@ -58,7 +58,7 @@ Abstract:
 static 
 KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerAudioEngineSupportedDeviceFormats[] =
 {
-    { // Only 48KHz stereo supported
+    { // Only 16KHz mono supported
         {
             sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE),
             0,
@@ -71,15 +71,15 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerAudioEngineSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                48000,
-                192000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
             16,
-            KSAUDIO_SPEAKER_STEREO,
+            KSAUDIO_SPEAKER_MONO,
             STATICGUIDOF(KSDATAFORMAT_SUBTYPE_PCM)
         }
     },
@@ -102,15 +102,15 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHostPinSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                48000,
-                192000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE)-sizeof(WAVEFORMATEX)
             },
             16,
-            KSAUDIO_SPEAKER_STEREO,
+            KSAUDIO_SPEAKER_MONO,
             STATICGUIDOF(KSDATAFORMAT_SUBTYPE_PCM)
         }
     }
@@ -118,7 +118,7 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerHostPinSupportedDeviceFormats[] =
 static
 KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerOffloadPinSupportedDeviceFormats[] =
 {
-    { // Only 48KHz stereo supported
+    { // Only 16KHz mono supported
         {
             sizeof(KSDATAFORMAT_WAVEFORMATEXTENSIBLE),
             0,
@@ -131,15 +131,15 @@ KSDATAFORMAT_WAVEFORMATEXTENSIBLE SpeakerOffloadPinSupportedDeviceFormats[] =
         {
             {
                 WAVE_FORMAT_EXTENSIBLE,
+                1,
+                16000,
+                32000,
                 2,
-                48000,
-                192000,
-                4,
                 16,
                 sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX)
             },
             16,
-            KSAUDIO_SPEAKER_STEREO,
+            KSAUDIO_SPEAKER_MONO,
             STATICGUIDOF(KSDATAFORMAT_SUBTYPE_PCM)
         }
     }
@@ -153,27 +153,27 @@ MODE_AND_DEFAULT_FORMAT SpeakerHostPinSupportedDeviceModes[] =
 {
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_RAW,
-        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 48KHz
+        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_DEFAULT,
-        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 48KHz
+        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_MEDIA,
-        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 48KHz
+        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_MOVIE,
-        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 48KHz
+        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_COMMUNICATIONS,
-        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 48KHz
+        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_NOTIFICATION,
-        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 48KHz
+        &SpeakerHostPinSupportedDeviceFormats[0].DataFormat  // 16KHz
     }
 };
 
@@ -182,11 +182,11 @@ MODE_AND_DEFAULT_FORMAT SpeakerOffloadPinSupportedDeviceModes[] =
 {
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_DEFAULT,
-        &SpeakerOffloadPinSupportedDeviceFormats[0].DataFormat // 48KHz
+        &SpeakerOffloadPinSupportedDeviceFormats[0].DataFormat // 16KHz
     },
     {
         STATIC_AUDIO_SIGNALPROCESSINGMODE_MEDIA,
-        &SpeakerOffloadPinSupportedDeviceFormats[0].DataFormat // 48KHz
+        &SpeakerOffloadPinSupportedDeviceFormats[0].DataFormat // 16KHz
     }
 };
 


### PR DESCRIPTION
## Summary
- change SysVAD speaker formats to 16 kHz 16-bit mono
- update headphone speaker formats to match
- adjust folkaurix service capture format and recognition config

## Testing
- `python -m py_compile Test/play_audio.py Test/test_google_speech.py`

------
https://chatgpt.com/codex/tasks/task_b_684fc54a9c608324882c86ff030feb2a