### PR TITLE
Enable peak meter for render devices

### DIFF
--- a/sysvad/EndpointsCommon/minwavertstream.cpp
+++ b/sysvad/EndpointsCommon/minwavertstream.cpp
@@ -1665,7 +1665,13 @@ VOID CMiniportWaveRTStream::UpdatePeakMeter(
         m_plPeakMeter[c] = val;
         if (adapter)
         {
-            adapter->MixerPeakMeterWrite(KSNODE_TOPO_PEAKMETER, c, val);
+            ULONG nodeId = KSNODE_TOPO_PEAKMETER;
+            if (m_pMiniport->m_DeviceType == eSpeakerDevice ||
+                m_pMiniport->m_DeviceType == eSpeakerHpDevice)
+            {
+                nodeId = 0;
+            }
+            adapter->MixerPeakMeterWrite(nodeId, c, val);
         }
     }
 }

--- a/sysvad/EndpointsCommon/speakerhptoptable.h
+++ b/sysvad/EndpointsCommon/speakerhptoptable.h
@@ -112,7 +112,8 @@ static
 PCCONNECTION_DESCRIPTOR SpeakerHpTopoMiniportConnections[] =
 {
   //  FromNode,                     FromPin,                        ToNode,                      ToPin
-  {   PCFILTER_NODE,                KSPIN_TOPO_WAVEOUT_SOURCE,      PCFILTER_NODE,               KSPIN_TOPO_LINEOUT_DEST}
+  {   PCFILTER_NODE,                KSPIN_TOPO_WAVEOUT_SOURCE,      KSNODE_TOPO_PEAKMETER,       1 },
+  {   KSNODE_TOPO_PEAKMETER,        0,                              PCFILTER_NODE,               KSPIN_TOPO_LINEOUT_DEST }
 };
 
 
@@ -131,6 +132,20 @@ PCPROPERTY_ITEM PropertiesSpeakerHpTopoFilter[] =
         KSPROPERTY_JACK_DESCRIPTION2,
         KSPROPERTY_TYPE_GET | KSPROPERTY_TYPE_BASICSUPPORT,
         PropertyHandler_SpeakerHpTopoFilter
+    },
+    {
+        &KSPROPSETID_Audio,
+        KSPROPERTY_AUDIO_PEAKMETER2,
+        KSPROPERTY_TYPE_GET |
+        KSPROPERTY_TYPE_BASICSUPPORT,
+        PropertyHandler_Topology
+    },
+    {
+        &KSPROPSETID_Audio,
+        KSPROPERTY_AUDIO_CPU_RESOURCES,
+        KSPROPERTY_TYPE_GET |
+        KSPROPERTY_TYPE_BASICSUPPORT,
+        PropertyHandler_Topology
     },
     {
         &KSPROPSETID_AudioResourceManagement,
@@ -154,6 +169,40 @@ DEFINE_PCAUTOMATION_TABLE_PROP_EVENT(AutomationSpeakerHpTopoFilter, PropertiesSp
 
 //=============================================================================
 static
+PCPROPERTY_ITEM SpeakerHpPropertiesPeakMeter[] =
+{
+  {
+    &KSPROPSETID_Audio,
+    KSPROPERTY_AUDIO_PEAKMETER2,
+    KSPROPERTY_TYPE_GET | KSPROPERTY_TYPE_BASICSUPPORT,
+    PropertyHandler_Topology
+  },
+  {
+    &KSPROPSETID_Audio,
+    KSPROPERTY_AUDIO_CPU_RESOURCES,
+    KSPROPERTY_TYPE_GET | KSPROPERTY_TYPE_BASICSUPPORT,
+    PropertyHandler_Topology
+  }
+};
+
+DEFINE_PCAUTOMATION_TABLE_PROP(AutomationSpeakerHpPeakMeter, SpeakerHpPropertiesPeakMeter);
+
+//=============================================================================
+static
+PCNODE_DESCRIPTOR SpeakerHpTopologyNodes[] =
+{
+  // KSNODE_TOPO_PEAKMETER
+  {
+    0,                                // Flags
+    &AutomationSpeakerHpPeakMeter,     // AutomationTable
+    &KSNODETYPE_PEAKMETER,             // Type
+    &KSAUDFNAME_PEAKMETER              // Name
+  }
+};
+
+
+//=============================================================================
+static
 PCFILTER_DESCRIPTOR SpeakerHpTopoMiniportFilterDescriptor =
 {
   0,                                                // Version
@@ -162,8 +211,8 @@ PCFILTER_DESCRIPTOR SpeakerHpTopoMiniportFilterDescriptor =
   SIZEOF_ARRAY(SpeakerHpTopoMiniportPins),          // PinCount
   SpeakerHpTopoMiniportPins,                        // Pins
   sizeof(PCNODE_DESCRIPTOR),                        // NodeSize
-  0,                                                // NodeCount
-  NULL,                                             // Nodes
+  SIZEOF_ARRAY(SpeakerHpTopologyNodes),             // NodeCount
+  SpeakerHpTopologyNodes,                           // Nodes
   SIZEOF_ARRAY(SpeakerHpTopoMiniportConnections),   // ConnectionCount
   SpeakerHpTopoMiniportConnections,                 // Connections
   0,                                                // CategoryCount

--- a/sysvad/EndpointsCommon/speakertoptable.h
+++ b/sysvad/EndpointsCommon/speakertoptable.h
@@ -119,7 +119,8 @@ static
 PCCONNECTION_DESCRIPTOR SpeakerTopoMiniportConnections[] =
 {
   //  FromNode,                     FromPin,                        ToNode,                      ToPin
-  {   PCFILTER_NODE,                KSPIN_TOPO_WAVEOUT_SOURCE,      PCFILTER_NODE,               KSPIN_TOPO_LINEOUT_DEST}
+  {   PCFILTER_NODE,                KSPIN_TOPO_WAVEOUT_SOURCE,      KSNODE_TOPO_PEAKMETER,       1 },
+  {   KSNODE_TOPO_PEAKMETER,        0,                              PCFILTER_NODE,               KSPIN_TOPO_LINEOUT_DEST }
 };
 
 
@@ -149,6 +150,20 @@ PCPROPERTY_ITEM PropertiesSpeakerTopoFilter[] =
         PropertyHandler_SpeakerTopoFilter
     },
     {
+        &KSPROPSETID_Audio,
+        KSPROPERTY_AUDIO_PEAKMETER2,
+        KSPROPERTY_TYPE_GET |
+        KSPROPERTY_TYPE_BASICSUPPORT,
+        PropertyHandler_Topology
+    },
+    {
+        &KSPROPSETID_Audio,
+        KSPROPERTY_AUDIO_CPU_RESOURCES,
+        KSPROPERTY_TYPE_GET |
+        KSPROPERTY_TYPE_BASICSUPPORT,
+        PropertyHandler_Topology
+    },
+    {
         &KSPROPSETID_AudioResourceManagement,
         KSPROPERTY_AUDIORESOURCEMANAGEMENT_RESOURCEGROUP,
         KSPROPERTY_TYPE_SET,
@@ -167,6 +182,40 @@ DEFINE_PCAUTOMATION_TABLE_PROP(AutomationSpeakerTopoFilter, PropertiesSpeakerTop
 
 //=============================================================================
 static
+PCPROPERTY_ITEM SpeakerPropertiesPeakMeter[] =
+{
+  {
+    &KSPROPSETID_Audio,
+    KSPROPERTY_AUDIO_PEAKMETER2,
+    KSPROPERTY_TYPE_GET | KSPROPERTY_TYPE_BASICSUPPORT,
+    PropertyHandler_Topology
+  },
+  {
+    &KSPROPSETID_Audio,
+    KSPROPERTY_AUDIO_CPU_RESOURCES,
+    KSPROPERTY_TYPE_GET | KSPROPERTY_TYPE_BASICSUPPORT,
+    PropertyHandler_Topology
+  }
+};
+
+DEFINE_PCAUTOMATION_TABLE_PROP(AutomationSpeakerPeakMeter, SpeakerPropertiesPeakMeter);
+
+//=============================================================================
+static
+PCNODE_DESCRIPTOR SpeakerTopologyNodes[] =
+{
+  // KSNODE_TOPO_PEAKMETER
+  {
+    0,                                // Flags
+    &AutomationSpeakerPeakMeter,      // AutomationTable
+    &KSNODETYPE_PEAKMETER,            // Type
+    &KSAUDFNAME_PEAKMETER             // Name
+  }
+};
+
+
+//=============================================================================
+static
 PCFILTER_DESCRIPTOR SpeakerTopoMiniportFilterDescriptor =
 {
   0,                                            // Version
@@ -175,8 +224,8 @@ PCFILTER_DESCRIPTOR SpeakerTopoMiniportFilterDescriptor =
   SIZEOF_ARRAY(SpeakerTopoMiniportPins),        // PinCount
   SpeakerTopoMiniportPins,                      // Pins
   sizeof(PCNODE_DESCRIPTOR),                    // NodeSize
-  0,                                            // NodeCount
-  NULL,                                         // Nodes
+  SIZEOF_ARRAY(SpeakerTopologyNodes),           // NodeCount
+  SpeakerTopologyNodes,                         // Nodes
   SIZEOF_ARRAY(SpeakerTopoMiniportConnections), // ConnectionCount
   SpeakerTopoMiniportConnections,               // Connections
   0,                                            // CategoryCount


### PR DESCRIPTION
## Summary
- add peak meter node and properties to speaker topology
- add peak meter node and properties to headphone topology
- write peak meter data to the correct node for render streams

## Testing
- `python -m py_compile Test/play_audio.py Test/test_google_speech.py`

------
https://chatgpt.com/codex/tasks/task_b_684fd677da248324bf7eea715fd1700a