### PR TITLE
Add TTS output recording option

### DIFF
--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -15,12 +15,14 @@ desired architecture.
 
 ## Usage
 ```
-folkaurixsvc.exe [-f output.raw] [-l target-language]
+folkaurixsvc.exe [-f output.raw] [-tf tts.wav] [-l target-language]
 ```
 When started, the program lists all active speaker devices and lets the
 user choose one. Captured audio is streamed to Google Cloud and the
 translated speech is played immediately on the selected device. Use
-`-f` to specify an optional file where the raw PCM data will be saved.
+`-f` to specify an optional file where the raw PCM data will be saved. Use
+`-tf` to record synthesized speech written by the playback thread to a WAV
+file in addition to playing it on the selected device.
 Press **F9** during capture to stop the program. `-l` allows specifying
 the ISO language code used for translation (default `zh`). The speech
 recognizer automatically detects the input language from a set of


### PR DESCRIPTION
## Summary
- add `-tf/--ttsfile` option to record synthesized audio
- dump playback data into optional WAV file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6851189a4b048324ba9b5de77a90f10f