### PR TITLE
Fix Azure TTS output format

### DIFF
--- a/Test/realtime_google_pipeline.cpp
+++ b/Test/realtime_google_pipeline.cpp
@@ -231,7 +231,11 @@ int main(int argc, char* argv[]) {
                 auto text = it->second;
                 auto ttsConfig = SpeechConfig::FromSubscription(AZURE_KEY, AZURE_REGION);
                 ttsConfig->SetSpeechSynthesisLanguage(targetLang.c_str());
-                ttsConfig->SetSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat::Riff16Khz16BitMonoPcm);
+                // Use raw PCM to avoid embedding a WAV header, which
+                // interferes with playback when the bytes are fed directly
+                // to the audio device.
+                ttsConfig->SetSpeechSynthesisOutputFormat(
+                    SpeechSynthesisOutputFormat::Raw16Khz16BitMonoPcm);
                 auto ttsStream = AudioOutputStream::CreatePullStream();
                 auto ttsAudio = AudioConfig::FromStreamOutput(ttsStream);
                 auto synthesizer = SpeechSynthesizer::FromConfig(ttsConfig, ttsAudio);

--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -785,7 +785,11 @@ bool StartAzurePipeline(const std::string& targetLang)
             DPF(L"translated:%hs\n", text.c_str());
                 auto ttsConfig = SpeechConfig::FromSubscription(AZURE_KEY, AZURE_REGION);
                 ttsConfig->SetSpeechSynthesisLanguage("zh-TW");
-                ttsConfig->SetSpeechSynthesisOutputFormat(SpeechSynthesisOutputFormat::Riff16Khz16BitMonoPcm);
+                // Request raw PCM output so we can directly feed the bytes to
+                // the playback thread. The Riff* formats include a WAV header
+                // which resulted in noise being rendered.
+                ttsConfig->SetSpeechSynthesisOutputFormat(
+                    SpeechSynthesisOutputFormat::Raw16Khz16BitMonoPcm);
                 auto outStream = AudioOutputStream::CreatePullStream();
                 auto audioCfg = AudioConfig::FromStreamOutput(outStream);
                 auto synthesizer = SpeechSynthesizer::FromConfig(ttsConfig, audioCfg);


### PR DESCRIPTION
## Summary
- ensure Azure speech synthesis uses raw PCM output

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68512bff9ff48324b7ed5a86af7be567