### PR TITLE
Fix WAV output sample rate

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -1271,21 +1271,10 @@ int wmain(int argc, wchar_t** argv)
     bool useTtsFile = false;
     if (opts.ttsOutputFile)
     {
-#if API==Azure_API
-        WAVEFORMATEX ttsFormat = {};
-        ttsFormat.wFormatTag = WAVE_FORMAT_PCM;
-        ttsFormat.nChannels = 1;
-        ttsFormat.nSamplesPerSec = 16000;
-        ttsFormat.wBitsPerSample = 16;
-        ttsFormat.nBlockAlign =
-            ttsFormat.nChannels * ttsFormat.wBitsPerSample / 8;
-        ttsFormat.nAvgBytesPerSec =
-            ttsFormat.nSamplesPerSec * ttsFormat.nBlockAlign;
-        ttsFormat.cbSize = 0;
-        const WAVEFORMATEX* pTtsFormat = &ttsFormat;
-#else
+        // The audio written by the playback thread is resampled to the
+        // device's mix format. Use the same format for the output WAV file
+        // to avoid mismatched headers that would cause slowed playback.
         const WAVEFORMATEX* pTtsFormat = &renderFormat;
-#endif
 
         if (!OpenWaveFile(ttsWriter, opts.ttsOutputFile, pTtsFormat))
         {


### PR DESCRIPTION
## Summary
- ensure TTS WAV files use the device render format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_b_6851416556cc8324b6e1bb3e4780521e