### PR TITLE
Add dual TTS output files

### DIFF
--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -15,14 +15,16 @@ desired architecture.
 
 ## Usage
 ```
-folkaurixsvc.exe [-f output.raw] [-tf tts.wav] [-l target-language]
+folkaurixsvc.exe [-f output.raw] [-tf output.wav] [-l target-language]
 ```
 When started, the program lists all active speaker devices and lets the
 user choose one. Captured audio is streamed to Google Cloud and the
 translated speech is played immediately on the selected device. Use
 `-f` to specify an optional file where the raw PCM data will be saved. Use
-`-tf` to record synthesized speech written by the playback thread to a WAV
-file in addition to playing it on the selected device.
+`-tf` to specify a base filename for saving synthesized speech. Two files
+`output1.wav` and `output2.wav` will be created where `output1.wav` contains
+the audio before resampling and `output2.wav` contains the resampled audio
+that is also played on the selected device.
 Press **F9** during capture to stop the program. `-l` allows specifying
 the ISO language code used for translation (default `zh`). The speech
 recognizer automatically detects the input language from a set of


### PR DESCRIPTION
## Summary
- allow `-tf` option to output both raw and resampled TTS WAV files
- record raw and resampled audio in `PlaybackThread`
- document new behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685145e32d7c832488f34987ee53e1ae