### PR TITLE
Fix sample rate mismatch in TTS pipeline

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -1399,8 +1399,10 @@ int wmain(int argc, wchar_t** argv)
 #if API==GOOGLE
     auto ttsEncoding = EncodingFromWaveFormat(
         reinterpret_cast<const WAVEFORMATEX&>(renderFormat));
+    // Request TTS output at 16 kHz to match the resampler's expected
+    // source rate.
     std::thread pipeline(StartRealtimePipeline, opts.targetLang, ttsEncoding,
-                         renderFormat.nSamplesPerSec);
+                         16000);
 #elif API == Azure_API
     std::thread pipeline(StartAzurePipeline, opts.targetLang);
 #endif


### PR DESCRIPTION
## Summary
- ensure TTS service returns 16 kHz audio for resampling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685147ef88c483249544e4e009922fd3