### PR TITLE
Fix resampler shift operations

### DIFF
--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -490,11 +490,11 @@ static std::vector<char> ResampleToRenderFormat(const std::vector<char>& input,
             }
             else if (outFmt.wBitsPerSample == 32)
             {
-                int32Dst[i * outFmt.nChannels + ch] = static_cast<int32_t>(sample) << 16;
+                int32Dst[i * outFmt.nChannels + ch] = static_cast<int32_t>(sample) * 65536;
             }
             else if (outFmt.wBitsPerSample == 24)
             {
-                int32_t val = static_cast<int32_t>(sample) << 8;
+                int32_t val = static_cast<int32_t>(sample) * 256;
                 size_t offset = (i * outFmt.nChannels + ch) * 3;
                 int24Dst[offset] = static_cast<uint8_t>(val & 0xFF);
                 int24Dst[offset + 1] = static_cast<uint8_t>((val >> 8) & 0xFF);


### PR DESCRIPTION
## Summary
- fix undefined behavior in `ResampleToRenderFormat`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_b_685224c1ada08324b9d26e4dc0af0c77