### PR TITLE
Use environment variable for Azure key

### DIFF
--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -15,8 +15,10 @@ desired architecture.
 
 ## Usage
 ```
-folkaurixsvc.exe [-f output.raw] [-tf output.wav] [-l target-language]
+folkaurixsvc.exe [-f output.raw] [-tf output.wav] [-l target-language] [-k azure-key]
 ```
+If `-k` is omitted, the program reads the Azure Speech subscription key from
+the `AZURE_KEY` environment variable.
 When started, the program lists all active speaker devices and lets the
 user choose one. Captured audio is streamed to Google Cloud and the
 translated speech is played immediately on the selected device. Use


### PR DESCRIPTION
## Summary
- remove hardcoded `AZURE_KEY`
- allow providing key via `-k` option or `AZURE_KEY` env var
- document new option and env var in README

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_b_685239350d1c8324953a5c931d90740d