### PR TITLE
Enable toggling of loopback buffer

### DIFF
--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -8,6 +8,11 @@ translation and text‑to‑speech synthesis.  The translated speech is
 played back through the system default speaker using the Azure Speech
 SDK. Optionally the raw PCM data can also be written to a file.
 
+The driver also supports the `IOCTL_SYSVAD_SET_LOOPBACK_ENABLED`
+control code which toggles whether captured audio is written to the
+loopback buffer. `folkaurixsvc` sends this IOCTL with `TRUE` when it
+starts recording and with `FALSE` just before exiting.
+
 ## Building
 The project is a standard Visual Studio console application.  Add
 `folkaurixsvc.cpp` to a new Win32 project and build for x64 or any

--- a/folkaurixsvc/folkaurixsvc.cpp
+++ b/folkaurixsvc/folkaurixsvc.cpp
@@ -54,6 +54,9 @@
 #ifndef IOCTL_SYSVAD_GET_LOOPBACK_DATA
 #define IOCTL_SYSVAD_GET_LOOPBACK_DATA CTL_CODE(FILE_DEVICE_UNKNOWN, 0x800, METHOD_OUT_DIRECT, FILE_READ_ACCESS)
 #endif
+#ifndef IOCTL_SYSVAD_SET_LOOPBACK_ENABLED
+#define IOCTL_SYSVAD_SET_LOOPBACK_ENABLED CTL_CODE(FILE_DEVICE_UNKNOWN, 0x801, METHOD_BUFFERED, FILE_WRITE_ACCESS)
+#endif
 
 #ifdef _DEBUG
 #define DPF_ENTER() wprintf(L"[ENTER] %S\n", __FUNCTION__)
@@ -1004,6 +1007,20 @@ int wmain(int argc, wchar_t** argv)
         return 1;
     }
 
+    // Enable loopback capture in the driver
+    {
+        BOOLEAN enable = TRUE;
+        DWORD returned = 0;
+        DeviceIoControl(hDevice,
+                        IOCTL_SYSVAD_SET_LOOPBACK_ENABLED,
+                        &enable,
+                        sizeof(enable),
+                        nullptr,
+                        0,
+                        &returned,
+                        nullptr);
+    }
+
     WaveFileWriter wavWriter;
     bool useFile = false;
     if (opts.outputFile)
@@ -1034,6 +1051,20 @@ int wmain(int argc, wchar_t** argv)
 
     if (useFile)
         FinalizeWaveFile(wavWriter);
+
+    // Disable loopback capture before closing the handle
+    {
+        BOOLEAN enable = FALSE;
+        DWORD returned = 0;
+        DeviceIoControl(hDevice,
+                        IOCTL_SYSVAD_SET_LOOPBACK_ENABLED,
+                        &enable,
+                        sizeof(enable),
+                        nullptr,
+                        0,
+                        &returned,
+                        nullptr);
+    }
 
     CloseHandle(hDevice);
 

--- a/sysvad/EndpointsCommon/minwavertstream.cpp
+++ b/sysvad/EndpointsCommon/minwavertstream.cpp
@@ -1594,7 +1594,10 @@ ByteDisplacement - # of bytes to process.
     {
         ULONG runWrite = min(ByteDisplacement, m_ulDmaBufferSize - bufferOffset);
         m_SaveData.WriteData(m_pDmaBuffer + bufferOffset, runWrite);
-        LoopbackBuffer_Write(m_pDmaBuffer + bufferOffset, runWrite);
+        if (g_LoopbackEnabled)
+        {
+            LoopbackBuffer_Write(m_pDmaBuffer + bufferOffset, runWrite);
+        }
         UpdatePeakMeter(m_pDmaBuffer + bufferOffset, runWrite);
         bufferOffset = (bufferOffset + runWrite) % m_ulDmaBufferSize;
         ByteDisplacement -= runWrite;

--- a/sysvad/loopback.cpp
+++ b/sysvad/loopback.cpp
@@ -1,6 +1,7 @@
 #include "loopback.h"
 
 static LOOPBACK_BUFFER g_LoopbackBuffer = {0};
+BOOLEAN g_LoopbackEnabled = FALSE;
 
 NTSTATUS LoopbackBuffer_Initialize()
 {

--- a/sysvad/loopback.h
+++ b/sysvad/loopback.h
@@ -5,6 +5,7 @@
 typedef unsigned char* PBYTE;   // 避免拉 windows.h
 
 #define IOCTL_SYSVAD_GET_LOOPBACK_DATA CTL_CODE(FILE_DEVICE_UNKNOWN, 0x800, METHOD_OUT_DIRECT, FILE_READ_ACCESS)
+#define IOCTL_SYSVAD_SET_LOOPBACK_ENABLED CTL_CODE(FILE_DEVICE_UNKNOWN, 0x801, METHOD_BUFFERED, FILE_WRITE_ACCESS)
 
 #define LOOPBACK_BUFFER_SIZE 65536
 #define LOOPBACK_POOLTAG 'LPBK'
@@ -24,6 +25,8 @@ void LoopbackBuffer_Write(_In_reads_bytes_(Length) PBYTE Data, _In_ ULONG Length
 ULONG LoopbackBuffer_Read(_Out_writes_bytes_(Length) PBYTE Data, _In_ ULONG Length);
 ULONG LoopbackBuffer_Available();
 KEVENT* LoopbackBuffer_GetEvent();
+
+extern BOOLEAN g_LoopbackEnabled;
 
 NTSTATUS LoopbackControl_CreateDevice(_In_ PDRIVER_OBJECT DriverObject);
 void LoopbackControl_DeleteDevice();

--- a/sysvad/loopbackcontrol.cpp
+++ b/sysvad/loopbackcontrol.cpp
@@ -61,6 +61,20 @@ static NTSTATUS LoopbackDispatch(_In_ PDEVICE_OBJECT DeviceObject, _Inout_ PIRP 
                 status = STATUS_INSUFFICIENT_RESOURCES;
             }
         }
+        else if (irpSp->Parameters.DeviceIoControl.IoControlCode == IOCTL_SYSVAD_SET_LOOPBACK_ENABLED)
+        {
+            if (irpSp->Parameters.DeviceIoControl.InputBufferLength >= sizeof(BOOLEAN) &&
+                Irp->AssociatedIrp.SystemBuffer)
+            {
+                BOOLEAN enable = *(PBOOLEAN)Irp->AssociatedIrp.SystemBuffer;
+                g_LoopbackEnabled = enable ? TRUE : FALSE;
+                status = STATUS_SUCCESS;
+            }
+            else
+            {
+                status = STATUS_INVALID_PARAMETER;
+            }
+        }
         break;
     default:
         break;


### PR DESCRIPTION
## Summary
- add IOCTL_SYSVAD_SET_LOOPBACK_ENABLED
- maintain global `g_LoopbackEnabled` flag
- handle the new IOCTL in the driver
- only write to loopback buffer when enabled
- enable loopback on service start and disable on exit
- document the new IOCTL in folkaurixsvc README

## Testing
- `echo "Running dummy tests" && true`

------
https://chatgpt.com/codex/tasks/task_b_68535d96313c83248835aad8b7eadf59