### PR TITLE
Update README for loopback clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ FolkAurix brings together a virtual audio driver based on Microsoft's SysVAD sam
 ## Directory layout
 
 - **sysvad/** – Modified [SysVAD Virtual Audio Device Driver](sysvad/README.md) sample providing loopback and other virtual endpoints.
-- **folkaurixsvc/** – [folkaurixsvc](folkaurixsvc/README.md) console application that records from the SysVAD loopback capture device using WASAPI and sends the audio to the cloud.
+- **folkaurixsvc/** – [folkaurixsvc](folkaurixsvc/README.md) console application that records from the driver-implemented "FolkAurix Loopback" capture device using the WASAPI `IAudioClient` interface and sends the audio to the cloud.
 - **Test/** – [Example scripts](Test/README.md) for playing audio files, running real-time translation pipelines and testing Google Speech APIs.
 
 ## Quick start
 
 1. Build and install the driver contained in `sysvad` using Visual Studio. Detailed instructions and prerequisites are covered in [sysvad/README.md](sysvad/README.md).
 2. Build the service found in `folkaurixsvc` (open the solution file and compile for the desired architecture). See [folkaurixsvc/README.md](folkaurixsvc/README.md) for usage options.
-3. Run `folkaurixsvc.exe`. Captured speech is recognised, translated and played back immediately through the default speaker.
+3. Run `folkaurixsvc.exe`. The service uses `IAudioClient` to capture audio from the driver-provided "FolkAurix Loopback" endpoint. Captured speech is recognised, translated and played back immediately through the default speaker.
 4. Optional: use the utilities in the `Test` directory to play audio or experiment with the real-time translation pipeline. See [Test/README.md](Test/README.md) for command examples.
 
 This repository assumes you already have the necessary credentials for Azure/Google Cloud services when using the speech features.

--- a/folkaurixsvc/README.md
+++ b/folkaurixsvc/README.md
@@ -1,10 +1,12 @@
 # folkaurixsvc
 
 This is a simple user‑mode application that reads audio captured by the
-SysVAD loopback device.  It now uses the standard WASAPI audio client
-interface to record from the "FolkAurix Loopback" capture endpoint.
-Captured PCM blocks are streamed to Google Cloud for speech recognition
-and translation.  The translated speech is played back through the
+driver‑provided "FolkAurix Loopback" device. Unlike the operating system
+loopback facility, this capture endpoint is implemented entirely in the
+FolkAurix driver. The service records the device through the standard
+WASAPI `IAudioClient` interface. Captured PCM blocks are streamed to
+Google Cloud for speech recognition and translation. The translated
+speech is played back through the
 system default speaker using the Azure Speech SDK. Optionally the raw
 PCM data can also be written to a file.
 


### PR DESCRIPTION
## Summary
- clarify that the "FolkAurix Loopback" device is implemented by the driver
- note that `folkaurixsvc` captures audio through `IAudioClient`

## Testing
- `python3 -m py_compile Test/play_audio.py Test/test_google_speech.py`


------
https://chatgpt.com/codex/tasks/task_b_68538660ba088324b9d2a62d2c3c5004