### PR TITLE
Add device listing option to playback script

### DIFF
--- a/Test/README.md
+++ b/Test/README.md
@@ -21,7 +21,8 @@ pip install sounddevice soundfile
 python play_audio.py <audio-file> --device <device-name-or-id>
 ```
 
-Use `python -m sounddevice` to list available devices.
+Run `python play_audio.py --list-devices` to list the available input and output
+devices. You can also use `python -m sounddevice` for detailed information.
 
 ## Real-time Speech Translation Example
 

--- a/Test/play_audio.py
+++ b/Test/play_audio.py
@@ -12,9 +12,31 @@ def main():
         "--device",
         type=str,
         default=None,
-        help="Output device name or index (see sounddevice.query_devices())",
+        help="Output device name or index",
+    )
+    parser.add_argument(
+        "-l",
+        "--list-devices",
+        action="store_true",
+        help="List available input and output devices and exit",
     )
     args = parser.parse_args()
+
+    if args.list_devices:
+        devices = sd.query_devices()
+        default_in, default_out = sd.default.device
+        print("Output devices:")
+        for idx, dev in enumerate(devices):
+            if dev["max_output_channels"] > 0:
+                marker = " (default)" if idx == default_out else ""
+                print(f"{idx}: {dev['name']}{marker}")
+
+        print("\nInput devices:")
+        for idx, dev in enumerate(devices):
+            if dev["max_input_channels"] > 0:
+                marker = " (default)" if idx == default_in else ""
+                print(f"{idx}: {dev['name']}{marker}")
+        return
 
     data, samplerate = sf.read(args.filename, dtype="float32")
     sd.play(data, samplerate, device=args.device)


### PR DESCRIPTION
## Summary
- allow listing of audio devices in `play_audio.py`
- document the `--list-devices` flag in `Test/README.md`

## Testing
- `python -m py_compile Test/play_audio.py Test/test_google_speech.py`


------
https://chatgpt.com/codex/tasks/task_b_685491758b0c832481c07ee8cf87e633