### PR TITLE
Limit SysVAD endpoints

### DIFF
--- a/sysvad/TabletAudioSample/minipairs.h
+++ b/sysvad/TabletAudioSample/minipairs.h
@@ -507,12 +507,9 @@ ENDPOINT_MINIPAIR MicArray3Miniports =
 // Render miniport pairs.
 //
 static
-PENDPOINT_MINIPAIR  g_RenderEndpoints[] = 
+PENDPOINT_MINIPAIR  g_RenderEndpoints[] =
 {
     &SpeakerMiniports,
-    &SpeakerHpMiniports,
-    &HdmiMiniports,
-    &SpdifMiniports,
 };
 
 #define g_cRenderEndpoints  (SIZEOF_ARRAY(g_RenderEndpoints))
@@ -522,12 +519,9 @@ PENDPOINT_MINIPAIR  g_RenderEndpoints[] =
 // Capture miniport pairs.
 //
 static
-PENDPOINT_MINIPAIR  g_CaptureEndpoints[] = 
+PENDPOINT_MINIPAIR  g_CaptureEndpoints[] =
 {
     &MicInMiniports,
-    &MicArray1Miniports,
-    &MicArray2Miniports,
-    &MicArray3Miniports,
 };
 
 #define g_cCaptureEndpoints (SIZEOF_ARRAY(g_CaptureEndpoints))


### PR DESCRIPTION
## Summary
- expose only a single render endpoint
- expose only a single mic-in capture endpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6854a5de8b548324a4bd49bc250b27e4