### PR TITLE
Implement zero-copy loopback

### DIFF
--- a/sysvad/EndpointsCommon/minwavert.h
+++ b/sysvad/EndpointsCommon/minwavert.h
@@ -178,6 +178,10 @@ private:
 
     AUDIOMODULE *                       m_pAudioModules;
 
+    BYTE*                               m_pRenderBuffer;
+    PMDL                                m_pRenderMdl;
+    ULONG                               m_ulRenderBufferSize;
+
 protected:
     PADAPTERCOMMON                      m_pAdapterCommon;
     ULONG                               m_DeviceFlags;
@@ -233,11 +237,18 @@ public:
     );
     
     NTSTATUS IsFormatSupported
-    ( 
-        _In_ ULONG          _ulPin, 
+    (
+        _In_ ULONG          _ulPin,
         _In_ BOOLEAN        _bCapture,
         _In_ PKSDATAFORMAT  _pDataFormat
     );
+
+    VOID SetRenderBuffer(_In_ BYTE* Buffer, _In_ PMDL Mdl, _In_ ULONG Size);
+    VOID ClearRenderBuffer();
+    BYTE* GetRenderBuffer();
+    PMDL GetRenderMdl();
+    ULONG GetRenderBufferSize();
+    VOID UpdateCaptureStreams(_In_ LARGE_INTEGER ilQPC);
 
     static NTSTATUS GetAttributesFromAttributeList
     (
@@ -300,7 +311,10 @@ public:
         m_DeviceFlags(MiniportPair->DeviceFlags),
         m_pMiniportPair(MiniportPair),
         m_pAudioModules(NULL),
-        m_pPortClsNotifications(NULL)
+        m_pPortClsNotifications(NULL),
+        m_pRenderBuffer(NULL),
+        m_pRenderMdl(NULL),
+        m_ulRenderBufferSize(0)
     {
         PAGED_CODE();
 


### PR DESCRIPTION
## Summary
- add shared render buffer fields to `CMiniportWaveRT`
- expose helper methods for render buffer access and capture update
- allocate capture buffers using the render DMA buffer
- skip timer for capture streams and synchronize positions from render
- clear shared buffer when render stream closes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6854a97875408324964b467b870290ec