### PR TITLE
Fix unreferenced parameter in driver stream

### DIFF
--- a/sysvad/EndpointsCommon/MiniportStreamAudioEngineNode.cpp
+++ b/sysvad/EndpointsCommon/MiniportStreamAudioEngineNode.cpp
@@ -943,10 +943,12 @@ NTSTATUS CMiniportWaveRTStream::SetLoopbackProtection(_In_ CONSTRICTOR_OPTION pr
     PAGED_CODE ();
     DPF_ENTER(("[CMiniportWaveRTStream::SetLoopbackProtection]"));
 
+    UNREFERENCED_PARAMETER(protectionOption);
+
     //
     // Miniport driver mutes/unmutes the loopback here.
-    // 
-    
+    //
+
     return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary
- silence a compiler warning for `SetLoopbackProtection`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6854b4d3ba5c83249e227455aded8896